### PR TITLE
support for ecc_compact, verification of supported keytypes

### DIFF
--- a/packages/crypto-react-native/src/Address.ts
+++ b/packages/crypto-react-native/src/Address.ts
@@ -1,15 +1,19 @@
-import { bs58CheckEncode, bs58ToBin } from './utils'
+import { bs58CheckEncode, bs58ToBin, bs58KeyType, bs58Version } from './utils'
 import { KeyType, SUPPORTED_KEY_TYPES } from './KeyType'
 
 export default class Address {
-  public version: number = 0
+  public version!: number
   public keyType!: KeyType
   public publicKey!: Uint8Array
 
-  constructor(keyType: KeyType, publicKey: Uint8Array) {
+  constructor(version: number, keyType: KeyType, publicKey: Uint8Array) {
     if (!SUPPORTED_KEY_TYPES.includes(keyType)) {
       throw new Error('unsupported key type')
     }
+    if (version !== 0) {
+      throw new Error('unsupported version')
+    }
+    this.version = version
     this.keyType = keyType
     this.publicKey = publicKey
   }
@@ -26,14 +30,11 @@ export default class Address {
   }
 
   static fromB58(b58: string): Address {
+    const version = bs58Version(b58)
+    const keyType = bs58KeyType(b58)
     const bin = bs58ToBin(b58)
-    return Address.fromBin(bin)
-  }
-
-  static fromBin(bin: Uint8Array): Address {
-    const keyType = Buffer.from(bin).slice(0, 1)[0] as KeyType
     const publicKey = Buffer.from(bin).slice(1)
-    return new Address(keyType, publicKey)
+    return new Address(version, keyType, publicKey)
   }
 
   static isValid(b58: string): boolean {

--- a/packages/crypto-react-native/src/KeyType.ts
+++ b/packages/crypto-react-native/src/KeyType.ts
@@ -1,0 +1,9 @@
+export const ECC_COMPACT_KEY_TYPE = 0
+export const ED25519_KEY_TYPE = 1
+
+export const SUPPORTED_KEY_TYPES = [
+  ECC_COMPACT_KEY_TYPE,
+  ED25519_KEY_TYPE,
+]
+
+export type KeyType = number

--- a/packages/crypto-react-native/src/Keypair.ts
+++ b/packages/crypto-react-native/src/Keypair.ts
@@ -1,6 +1,7 @@
 import Sodium from 'react-native-sodium'
 import Mnemonic from './Mnemonic'
 import Address from './Address'
+import { ED25519_KEY_TYPE } from './KeyType'
 
 interface SodiumKeyPair {
   sk: string
@@ -20,7 +21,7 @@ export default class Keypair {
   }
 
   get address(): Address {
-    return new Address(this.publicKey)
+    return new Address(ED25519_KEY_TYPE ,this.publicKey)
   }
 
   static async makeRandom(): Promise<Keypair> {

--- a/packages/crypto-react-native/src/Keypair.ts
+++ b/packages/crypto-react-native/src/Keypair.ts
@@ -21,7 +21,7 @@ export default class Keypair {
   }
 
   get address(): Address {
-    return new Address(ED25519_KEY_TYPE ,this.publicKey)
+    return new Address(0, ED25519_KEY_TYPE ,this.publicKey)
   }
 
   static async makeRandom(): Promise<Keypair> {

--- a/packages/crypto-react-native/src/utils.ts
+++ b/packages/crypto-react-native/src/utils.ts
@@ -67,3 +67,15 @@ export const bs58ToBin = (bs58Address: string): Buffer => {
 
   return payload
 }
+
+export const bs58KeyType = (bs58Address: string): number => {
+  const bin = bs58ToBin(bs58Address)
+  const keyType = Buffer.from(bin).slice(0, 1)[0]
+  return keyType
+}
+
+export const bs58Version = (bs58Address: string): number => {
+  const bin = bs58.decode(bs58Address)
+  const version = bin.slice(0, 1)[0]
+  return version
+}

--- a/packages/crypto/src/Address.ts
+++ b/packages/crypto/src/Address.ts
@@ -1,15 +1,19 @@
-import { bs58CheckEncode, bs58ToBin } from './utils'
+import { bs58CheckEncode, bs58KeyType, bs58Version, bs58PublicKey } from './utils'
 import { KeyType, SUPPORTED_KEY_TYPES } from './KeyType'
 
 export default class Address {
-  public version: number = 0
+  public version!: number
   public keyType!: KeyType
   public publicKey!: Uint8Array
 
-  constructor(keyType: KeyType, publicKey: Uint8Array) {
+  constructor(version: number, keyType: KeyType, publicKey: Uint8Array) {
     if (!SUPPORTED_KEY_TYPES.includes(keyType)) {
       throw new Error('unsupported key type')
     }
+    if (version !== 0) {
+      throw new Error('unsupported version')
+    }
+    this.version = version
     this.keyType = keyType
     this.publicKey = publicKey
   }
@@ -26,14 +30,10 @@ export default class Address {
   }
 
   static fromB58(b58: string): Address {
-    const bin = bs58ToBin(b58)
-    return Address.fromBin(bin)
-  }
-
-  static fromBin(bin: Uint8Array): Address {
-    const keyType = Buffer.from(bin).slice(0, 1)[0] as KeyType
-    const publicKey = Buffer.from(bin).slice(1)
-    return new Address(keyType, publicKey)
+    const version = bs58Version(b58)
+    const keyType = bs58KeyType(b58)
+    const publicKey = bs58PublicKey(b58)
+    return new Address(version, keyType, publicKey)
   }
 
   static isValid(b58: string): boolean {

--- a/packages/crypto/src/KeyType.ts
+++ b/packages/crypto/src/KeyType.ts
@@ -1,0 +1,9 @@
+export const ECC_COMPACT_KEY_TYPE = 0
+export const ED25519_KEY_TYPE = 1
+
+export const SUPPORTED_KEY_TYPES = [
+  ECC_COMPACT_KEY_TYPE,
+  ED25519_KEY_TYPE,
+]
+
+export type KeyType = number

--- a/packages/crypto/src/Keypair.ts
+++ b/packages/crypto/src/Keypair.ts
@@ -2,6 +2,7 @@ import sodium from 'libsodium-wrappers'
 import type { KeyPair as SodiumKeyPair } from 'libsodium-wrappers'
 import Mnemonic from './Mnemonic'
 import Address from './Address'
+import { ED25519_KEY_TYPE } from './KeyType'
 
 
 // extend SodiumKeyPair?
@@ -19,7 +20,7 @@ export default class Keypair {
   }
 
   get address(): Address {
-    return new Address(this.publicKey)
+    return new Address(ED25519_KEY_TYPE, this.publicKey)
   }
 
   static async makeRandom(): Promise<Keypair> {

--- a/packages/crypto/src/Keypair.ts
+++ b/packages/crypto/src/Keypair.ts
@@ -20,7 +20,7 @@ export default class Keypair {
   }
 
   get address(): Address {
-    return new Address(ED25519_KEY_TYPE, this.publicKey)
+    return new Address(0, ED25519_KEY_TYPE, this.publicKey)
   }
 
   static async makeRandom(): Promise<Keypair> {

--- a/packages/crypto/src/__tests__/Address.spec.ts
+++ b/packages/crypto/src/__tests__/Address.spec.ts
@@ -11,7 +11,7 @@ const BTC_ADDRESS = '18wxa7qM8C8AXmGwJj13C7sGqn8hyFdcdR'
 describe('b58', () => {
   it('returns a b58 check encoded representation of the address', async () => {
     const { bob } = await usersFixture()
-    const address = new Address(1, bob.publicKey)
+    const address = new Address(0, 1, bob.publicKey)
     expect(address.b58).toBe(bobB58)
   })
 
@@ -29,7 +29,7 @@ describe('b58', () => {
 describe('bin', () => {
   it('returns a binary representation of the address', async () => {
     const { bob } = await usersFixture()
-    const address = new Address(1, bob.publicKey)
+    const address = new Address(0, 1, bob.publicKey)
     expect(address.bin[0]).toBe(1)
   })
 })
@@ -50,7 +50,7 @@ describe('unsupported key types', () => {
 
   it('throws an error if initialized with an unsupported key type', async () => {
     expect(() => {
-      new Address(57, Buffer.from('some random public key'))
+      new Address(0, 57, Buffer.from('some random public key'))
     }).toThrow()
   })
 })
@@ -72,5 +72,14 @@ describe('isValid', () => {
 
   it('returns false if the key type is unsupported', () => {
     expect(Address.isValid(BTC_ADDRESS)).toBeFalsy()
+  })
+})
+
+describe('unsupported versions', () => {
+  it('throws an error if b58 check encoded version is not 0', async () => {
+    const { bob } = await usersFixture()
+    expect(() => {
+      new Address(1, 1, bob.publicKey)
+    }).toThrow()
   })
 })

--- a/packages/crypto/src/__tests__/Address.spec.ts
+++ b/packages/crypto/src/__tests__/Address.spec.ts
@@ -1,18 +1,35 @@
 import { Address } from '..'
-import { usersFixture, bobB58 } from '../../../../integration_tests/fixtures/users'
+import {
+  usersFixture,
+  bobB58,
+} from '../../../../integration_tests/fixtures/users'
+
+const ECC_COMPACT_ADDRESS =
+  '112qB3YaH5bZkCnKA5uRH7tBtGNv2Y5B4smv1jsmvGUzgKT71QpE'
+const BTC_ADDRESS = '18wxa7qM8C8AXmGwJj13C7sGqn8hyFdcdR'
 
 describe('b58', () => {
   it('returns a b58 check encoded representation of the address', async () => {
     const { bob } = await usersFixture()
-    const address = new Address(bob.publicKey)
+    const address = new Address(1, bob.publicKey)
     expect(address.b58).toBe(bobB58)
+  })
+
+  it('supports ed25519 addresses', () => {
+    const address = Address.fromB58(bobB58)
+    expect(address.b58).toBe(bobB58)
+  })
+
+  it('supports ecc_compact addresses', () => {
+    const address = Address.fromB58(ECC_COMPACT_ADDRESS)
+    expect(address.b58).toBe(ECC_COMPACT_ADDRESS)
   })
 })
 
 describe('bin', () => {
   it('returns a binary representation of the address', async () => {
     const { bob } = await usersFixture()
-    const address = new Address(bob.publicKey)
+    const address = new Address(1, bob.publicKey)
     expect(address.bin[0]).toBe(1)
   })
 })
@@ -21,5 +38,39 @@ describe('fromB58', () => {
   it('builds an Address from a b58 string', () => {
     const address = Address.fromB58(bobB58)
     expect(address.b58).toBe(bobB58)
+  })
+})
+
+describe('unsupported key types', () => {
+  it('throws an error if given an unsupported key type via B58', async () => {
+    expect(() => {
+      Address.fromB58(BTC_ADDRESS)
+    }).toThrow()
+  })
+
+  it('throws an error if initialized with an unsupported key type', async () => {
+    expect(() => {
+      new Address(57, Buffer.from('some random public key'))
+    }).toThrow()
+  })
+})
+
+describe('isValid', () => {
+  it('returns true if the address is valid and supported', () => {
+    expect(Address.isValid(bobB58)).toBeTruthy()
+    expect(Address.isValid(ECC_COMPACT_ADDRESS)).toBeTruthy()
+  })
+
+  it('returns false if the address is not valid', () => {
+    expect(Address.isValid('some bad address')).toBeFalsy()
+  })
+
+  it('returns false if the check decode fails', () => {
+    const badBobB58 = '13M8dUbxymE3xtiAXszRkGMmezMhBS8Li7wEsMojLdb4Sdxc4wb'
+    expect(Address.isValid(badBobB58)).toBeFalsy()
+  })
+
+  it('returns false if the key type is unsupported', () => {
+    expect(Address.isValid(BTC_ADDRESS)).toBeFalsy()
   })
 })

--- a/packages/crypto/src/utils.ts
+++ b/packages/crypto/src/utils.ts
@@ -7,9 +7,8 @@ export const randomBytes = async (n: number): Promise<Buffer> => {
   return Buffer.from(sodium.randombytes_buf(n))
 }
 
-export const sha256 = (buffer: Buffer | string): string => (
+export const sha256 = (buffer: Buffer | string): string =>
   createHash('sha256').update(buffer).digest().toString('hex')
-)
 
 export const lpad = (
   str: string | any[],
@@ -21,9 +20,12 @@ export const lpad = (
   return strOut
 }
 
-export const bytesToBinary = (bytes: any[]) => bytes
-  .map((x: { toString: (arg0: number) => string | any[] }) => lpad(x.toString(2), '0', 8))
-  .join('')
+export const bytesToBinary = (bytes: any[]) =>
+  bytes
+    .map((x: { toString: (arg0: number) => string | any[] }) =>
+      lpad(x.toString(2), '0', 8),
+    )
+    .join('')
 
 export const binaryToByte = (bin: string) => parseInt(bin, 2)
 
@@ -35,22 +37,19 @@ export const deriveChecksumBits = (entropyBuffer: Buffer | string) => {
   return bytesToBinary([].slice.call(hash)).slice(0, CS)
 }
 
-export const bs58CheckEncode = (version: number, binary: Buffer | Uint8Array): string => {
+export const bs58CheckEncode = (
+  version: number,
+  binary: Buffer | Uint8Array,
+): string => {
   // VPayload = <<Version:8/unsigned-integer, Payload/binary>>,
-  const vPayload = Buffer.concat([
-    Buffer.from([version]),
-    binary,
-  ])
+  const vPayload = Buffer.concat([Buffer.from([version]), binary])
 
   // <<Checksum:4/binary, _/binary>> = crypto:hash(sha256, crypto:hash(sha256, VPayload)),
   const checksum = sha256(Buffer.from(sha256(vPayload), 'hex'))
   const checksumBytes = Buffer.alloc(4, checksum, 'hex')
 
   // Result = <<VPayload/binary, Checksum/binary>>,
-  const result = Buffer.concat([
-    vPayload,
-    checksumBytes,
-  ])
+  const result = Buffer.concat([vPayload, checksumBytes])
 
   // base58:binary_to_base58(Result).
   return bs58.encode(result)
@@ -70,4 +69,22 @@ export const bs58ToBin = (bs58Address: string): Buffer => {
   }
 
   return payload
+}
+
+export const bs58KeyType = (bs58Address: string): number => {
+  const bin = bs58ToBin(bs58Address)
+  const keyType = Buffer.from(bin).slice(0, 1)[0]
+  return keyType
+}
+
+export const bs58Version = (bs58Address: string): number => {
+  const bin = bs58.decode(bs58Address)
+  const version = bin.slice(0, 1)[0]
+  return version
+}
+
+export const bs58PublicKey = (bs58Address: string): Buffer => {
+  const bin = bs58ToBin(bs58Address)
+  const publicKey = Buffer.from(bin).slice(1)
+  return publicKey
 }


### PR DESCRIPTION
adds support for ecc_compact key types and adds additional verification that a b58 address is derived from a key type we support.