### PR TITLE
Return all predicted oracle prices

### DIFF
--- a/packages/http/src/resources/Oracle.ts
+++ b/packages/http/src/resources/Oracle.ts
@@ -2,8 +2,9 @@ import { Balance, CurrencyType } from '@helium/currency'
 import type Client from '../Client'
 
 interface HTTPOraclePrice {
-  time: number
   price: number
+  height?: number
+  time?: number
 }
 
 interface OraclePrice {

--- a/packages/http/src/resources/Oracle.ts
+++ b/packages/http/src/resources/Oracle.ts
@@ -1,4 +1,4 @@
-import { Balance, CurrencyType } from '@helium/currency'
+import { Balance, CurrencyType, USDollars } from '@helium/currency'
 import type Client from '../Client'
 
 interface HTTPOraclePrice {
@@ -8,7 +8,7 @@ interface HTTPOraclePrice {
 }
 
 interface OraclePrice {
-  price: Balance<any>
+  price: Balance<USDollars>
   height?: number
   time?: number
 }

--- a/packages/http/src/resources/Oracle.ts
+++ b/packages/http/src/resources/Oracle.ts
@@ -1,5 +1,16 @@
-import type Client from '../Client'
 import { Balance, CurrencyType } from '@helium/currency'
+import type Client from '../Client'
+
+interface HTTPOraclePrice {
+  time: number
+  price: number
+}
+
+interface OraclePrice {
+  price: Balance<any>
+  height?: number
+  time?: number
+}
 
 export default class Oracle {
   private client!: Client
@@ -8,28 +19,31 @@ export default class Oracle {
     this.client = client
   }
 
-  async getCurrentPrice(): Promise<any> {
+  async getCurrentPrice(): Promise<OraclePrice> {
     const url = '/oracle/prices/current'
     const { data: { data: { price, block } } } = await this.client.get(url)
 
     return { price: new Balance(price, CurrencyType.usd), height: block }
   }
 
-  async getPriceAtBlock(height: number): Promise<any> {
+  async getPriceAtBlock(height: number): Promise<OraclePrice> {
     const url = `/oracle/prices/${height}`
     const { data: { data: { price, block } } } = await this.client.get(url)
 
     return { price: new Balance(price, CurrencyType.usd), height: block }
   }
 
-  async getPredictedPrice(): Promise<any> {
+  async getPredictedPrice(): Promise<OraclePrice[]> {
     const url = '/oracle/predictions'
     const response = await this.client.get(url)
     if (!response.data.data || !response.data.data.length) {
       return []
     }
 
-    const { data: { data: [{ price, time }] } } = response
-    return { price: new Balance(price, CurrencyType.usd), time }
+    const { data: { data: predictions } } = response
+    return predictions.map((prediction: HTTPOraclePrice) => ({
+      time: prediction.time,
+      price: new Balance(prediction.price, CurrencyType.usd),
+    }))
   }
 }

--- a/packages/http/src/resources/__tests__/Oracle.spec.ts
+++ b/packages/http/src/resources/__tests__/Oracle.spec.ts
@@ -51,8 +51,8 @@ describe('oracle predicted price exists', () => {
   it('gets the oracle price prediction', async () => {
     const client = new Client()
     const price = await client.oracle.getPredictedPrice()
-    expect(price.price.integerBalance).toBe(42040700)
-    expect(price.time).toBe(1594410146)
+    expect(price[0].price.integerBalance).toBe(42040700)
+    expect(price[0].time).toBe(1594410146)
   })
 })
 
@@ -74,8 +74,9 @@ describe('oracle predicted price has multiple values', () => {
   it('gets the first oracle price prediction', async () => {
     const client = new Client()
     const price = await client.oracle.getPredictedPrice()
-    expect(price.price.integerBalance).toBe(42040700)
-    expect(price.time).toBe(1594410146)
+    expect(price.length).toBe(2)
+    expect(price[0].price.integerBalance).toBe(42040700)
+    expect(price[0].time).toBe(1594410146)
   })
 })
 
@@ -91,7 +92,5 @@ describe('oracle predicted price is empty', () => {
     const price = await client.oracle.getPredictedPrice()
     expect(price).toBeInstanceOf(Array)
     expect(price.length).toBe(0)
-    expect(price.price).toBeUndefined()
-    expect(price.time).toBeUndefined()
   })
 })


### PR DESCRIPTION
Updates Oracle.getPredictedPrice() to match the API response and return an array of predicted prices.

https://developer.helium.com/blockchain/api/oracle#get-predicted-hnt-oracle-prices