### PR TITLE
Address#fromBin, PaymentV2#fromString

### DIFF
--- a/packages/crypto/src/Address.ts
+++ b/packages/crypto/src/Address.ts
@@ -36,6 +36,13 @@ export default class Address {
     return new Address(version, keyType, publicKey)
   }
 
+  static fromBin(bin: Buffer): Address {
+    const version = 0
+    const keyType = bin[0]
+    const publicKey = bin.slice(1, bin.length)
+    return new Address(version, keyType, publicKey)
+  }
+
   static isValid(b58: string): boolean {
     try {
       Address.fromB58(b58)

--- a/packages/crypto/src/__tests__/Address.spec.ts
+++ b/packages/crypto/src/__tests__/Address.spec.ts
@@ -34,6 +34,15 @@ describe('bin', () => {
   })
 })
 
+describe('fromBin', () => {
+  it('builds an Address from a binary representation', async () => {
+    const { bob } = await usersFixture()
+    const { bin } = new Address(0, 1, bob.publicKey)
+    const address = Address.fromBin(bin)
+    expect(address.b58).toBe(bob.address.b58)
+  })
+})
+
 describe('fromB58', () => {
   it('builds an Address from a b58 string', () => {
     const address = Address.fromB58(bobB58)

--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -1,5 +1,4 @@
 export { default as Mnemonic } from './Mnemonic'
 export { default as Keypair } from './Keypair'
 export { default as Address } from './Address'
-export type KeyType = number
 export * as utils from './utils'

--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -1,4 +1,5 @@
 export { default as Mnemonic } from './Mnemonic'
 export { default as Keypair } from './Keypair'
 export { default as Address } from './Address'
+export type KeyType = number
 export * as utils from './utils'

--- a/packages/transactions/README.md
+++ b/packages/transactions/README.md
@@ -16,3 +16,17 @@ Construct and serialize transaction primatives from their protobuf definitions.
 // sign transaction
 const signedTransaction = await transaction.sign({ payer: payerKeypair })
 ```
+
+## Deserialization
+
+```ts
+const paymentTxn = new PaymentV2({
+  payer,
+  payments,
+  nonce,
+})
+
+const serializedPaymentV2 = paymentTxn.toString()
+
+const deserializedPaymentV2 = PaymentV2.fromString(serializedPaymentV2)
+```

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -27,6 +27,7 @@
     "build": "yarn run clean && tsc"
   },
   "dependencies": {
+    "@helium/crypto": "^3.1.0",
     "@helium/proto": "^1.1.0",
     "long": "^4.0.0",
     "path": "^0.12.7"

--- a/packages/transactions/src/PaymentV2.ts
+++ b/packages/transactions/src/PaymentV2.ts
@@ -32,7 +32,7 @@ export default class PaymentV2 extends Transaction {
     this.payer = opts.payer
     this.payments = opts.payments || []
     this.nonce = opts.nonce
-    if (opts.fee) {
+    if (opts.fee !== undefined) {
       this.fee = opts.fee
     } else {
       this.fee = 0

--- a/packages/transactions/src/__tests__/PaymentV2.spec.ts
+++ b/packages/transactions/src/__tests__/PaymentV2.spec.ts
@@ -1,6 +1,10 @@
 import proto from '@helium/proto'
 import { PaymentV2, Transaction } from '..'
-import { usersFixture, bobB58, aliceB58 } from '../../../../integration_tests/fixtures/users'
+import {
+  usersFixture,
+  bobB58,
+  aliceB58,
+} from '../../../../integration_tests/fixtures/users'
 
 Transaction.config({
   txnFeeMultiplier: 5000,
@@ -35,7 +39,7 @@ test('create a PaymentV2', async () => {
   expect(payment.fee).toBe(35000)
 })
 
-describe('serialize', () => {
+describe('serialize and deserialize', () => {
   it('serializes a PaymentV2 txn', async () => {
     const payment = await paymentFixture()
     expect(payment.serialize().length).toBeGreaterThan(0)
@@ -48,6 +52,19 @@ describe('serialize', () => {
     const buf = Buffer.from(paymentString, 'base64')
     const decoded = proto.helium.blockchain_txn.decode(buf)
     expect(decoded.paymentV2?.nonce?.toString()).toBe('1')
+  })
+
+  it('deserializes from a base64 string', async () => {
+    const payment = await paymentFixture()
+    const paymentString = payment.toString()
+    const deserialized = PaymentV2.fromString(paymentString)
+    expect(deserialized.payer?.b58).toBe(payment.payer?.b58)
+    expect(deserialized.nonce).toBe(payment.nonce)
+    expect(deserialized.payments[0]?.amount).toBe(payment.payments[0]?.amount)
+    expect(deserialized.payments[0]?.payee.b58).toBe(
+      payment.payments[0]?.payee.b58,
+    )
+    expect(deserialized.fee).toBe(payment.fee)
   })
 })
 
@@ -70,5 +87,24 @@ describe('sign', () => {
     if (!signedPayment.signature) throw new Error('null')
 
     expect(Buffer.byteLength(Buffer.from(signedPayment.signature))).toBe(64)
+  })
+
+  it('preserves the signature when deserializing', async () => {
+    const { bob, alice } = await usersFixture()
+    const payment = new PaymentV2({
+      payer: bob.address,
+      payments: [
+        {
+          payee: alice.address,
+          amount: 10,
+        },
+      ],
+      nonce: 1,
+    })
+
+    const signedPayment = await payment.sign({ payer: bob })
+    const serializedPayment = signedPayment.toString()
+    const deserializedPayment = PaymentV2.fromString(serializedPayment)
+    expect(deserializedPayment.signature).toEqual(signedPayment.signature)
   })
 })

--- a/packages/transactions/src/utils.ts
+++ b/packages/transactions/src/utils.ts
@@ -21,8 +21,3 @@ export const toNumber = (long: Long | number | undefined | null): number | undef
   if (typeof long === 'number') return long
   return long.toNumber()
 }
-
-export const stripNull = (value: any): any => {
-  if (value === null) return undefined
-  return value
-}

--- a/packages/transactions/src/utils.ts
+++ b/packages/transactions/src/utils.ts
@@ -1,6 +1,28 @@
-/* eslint-disable import/prefer-default-export */
+import { Address } from '@helium/crypto'
+import Long from 'long'
+import { Addressable } from './types'
+
 export const toUint8Array = (
   str: string | Uint8Array | undefined | null,
 ): Uint8Array => Uint8Array.from(Buffer.from(str || ''))
 
 export const EMPTY_SIGNATURE = Uint8Array.from(Array(64).fill(0))
+
+export const toAddressable = (
+  bin: Buffer | Uint8Array | undefined | null,
+): Addressable | undefined => {
+  if (bin === undefined || bin === null) return undefined
+  const buf = Buffer.from(bin)
+  return Address.fromBin(buf)
+}
+
+export const toNumber = (long: Long | number | undefined | null): number | undefined => {
+  if (long === undefined || long === null) return undefined
+  if (typeof long === 'number') return long
+  return long.toNumber()
+}
+
+export const stripNull = (value: any): any => {
+  if (value === null) return undefined
+  return value
+}


### PR DESCRIPTION
- `@helium/crypto` adds `Address#fromBin` to construct and `Address` from its binary representation
- `@helium/transactions` adds `PaymentV2#fromString` to deserialize a PaymentV2 from its serialized string form