### PR TITLE
Fix 0 Amount Transfers

### DIFF
--- a/packages/transactions/src/TransferHotspotV1.ts
+++ b/packages/transactions/src/TransferHotspotV1.ts
@@ -60,7 +60,6 @@ export default class TransferHotspotV1 extends Transaction {
 
   serialize(): Uint8Array {
     const BlockchainTxn = proto.helium.blockchain_txn
-
     const transferHotspot = this.toProto()
     const txn = BlockchainTxn.create({ transferHotspot })
     return BlockchainTxn.encode(txn).finish()
@@ -117,8 +116,8 @@ export default class TransferHotspotV1 extends Transaction {
       buyerSignature: this.buyerSignature && !forSigning
         ? toUint8Array(this.buyerSignature) : null,
       buyerNonce: this.buyerNonce,
-      amountToSeller: this.amountToSeller,
-      fee: this.fee,
+      amountToSeller: this.amountToSeller ? this.amountToSeller : null,
+      fee: this.fee ? this.fee : null,
     })
   }
 


### PR DESCRIPTION
When the amount is 0 and we pass it into the proto for serialization the default value is actually getting serialized into the proto (which is not expected) and on the blockchain it doesnt get serialized in for default values which is what is supposed to happen.

For this reason transfers with 0 amount were failing. When we dont include these 0 values proto uses the default 0 and doesnt include them in the serialized transaction which makes everything line up correctly.