### PR TITLE
Add invalidReason to invalid witnesses

### DIFF
--- a/packages/http/src/models/Challenge.ts
+++ b/packages/http/src/models/Challenge.ts
@@ -152,8 +152,8 @@ const constructPath = (path: HTTPPathObject[]): Path[] => {
     }
     return {
       witnesses: pathObject.witnesses.map(
-        (witness) => {
-          let witnessObject = {
+        (witness) =>
+          ({
             timestamp: witness.timestamp,
             snr: witness.snr,
             signal: witness.signal,
@@ -161,14 +161,12 @@ const constructPath = (path: HTTPPathObject[]): Path[] => {
             owner: witness.owner,
             location: witness.location,
             isValid: isValidWitness(witness),
+            ...(witness.hasOwnProperty('invalid_reason') && { invalidReason: witness.invalid_reason }),
             gateway: witness.gateway,
             frequency: witness.frequency,
             datarate: witness.datarate,
             channel: witness.channel,
-          } as Witness
-          if (!isValidWitness(witness)) witnessObject = { ...witnessObject, invalidReason: witness.invalid_reason }
-          return witnessObject
-        },
+          } as Witness),
       ) as Witness[],
       receipt: hasReceipt
         ? ({

--- a/packages/http/src/models/Challenge.ts
+++ b/packages/http/src/models/Challenge.ts
@@ -48,6 +48,7 @@ export interface HTTPWitnessesObject {
   owner: string
   location: string
   is_valid: boolean
+  invalid_reason?: string
   gateway: string
   frequency: number
   datarate: number[]
@@ -104,6 +105,7 @@ export interface Witness {
   owner: string
   location: string
   isValid: boolean
+  invalidReason?: string
   gateway: string
   frequency: number
   datarate: number[]
@@ -150,19 +152,23 @@ const constructPath = (path: HTTPPathObject[]): Path[] => {
     }
     return {
       witnesses: pathObject.witnesses.map(
-        (witness) => ({
-          timestamp: witness.timestamp,
-          snr: witness.snr,
-          signal: witness.signal,
-          packetHash: witness.packet_hash,
-          owner: witness.owner,
-          location: witness.location,
-          isValid: isValidWitness(witness),
-          gateway: witness.gateway,
-          frequency: witness.frequency,
-          datarate: witness.datarate,
-          channel: witness.channel,
-        } as Witness),
+        (witness) => {
+          let witnessObject = {
+            timestamp: witness.timestamp,
+            snr: witness.snr,
+            signal: witness.signal,
+            packetHash: witness.packet_hash,
+            owner: witness.owner,
+            location: witness.location,
+            isValid: isValidWitness(witness),
+            gateway: witness.gateway,
+            frequency: witness.frequency,
+            datarate: witness.datarate,
+            channel: witness.channel,
+          } as Witness
+          if (!isValidWitness(witness)) witnessObject = { ...witnessObject, invalidReason: witness.invalid_reason }
+          return witnessObject
+        },
       ) as Witness[],
       receipt: hasReceipt
         ? ({

--- a/packages/http/src/models/__tests__/Challenge.spec.ts
+++ b/packages/http/src/models/__tests__/Challenge.spec.ts
@@ -28,19 +28,23 @@ export const mockLegacyWitness = (): HTTPWitnessesObject => ({
   channel: 4,
 } as HTTPWitnessesObject)
 
-export const mockWitness = (isValid = true): HTTPWitnessesObject => ({
-  timestamp: 1602013549762689800,
-  snr: 7,
-  signal: -103,
-  packet_hash: 'fake-packet_hash',
-  owner: 'fake-owner',
-  location: 'fake-location',
-  is_valid: isValid,
-  gateway: 'fake-witness-gateway',
-  frequency: 904.7000122070312,
-  datarate: [83, 70, 56, 66, 87, 49, 50, 53],
-  channel: 4,
-})
+export const mockWitness = (isValid = true): HTTPWitnessesObject => {
+  let witnessObject = {
+    timestamp: 1602013549762689800,
+    snr: 7,
+    signal: -103,
+    packet_hash: 'fake-packet_hash',
+    owner: 'fake-owner',
+    location: 'fake-location',
+    is_valid: isValid,
+    gateway: 'fake-witness-gateway',
+    frequency: 904.7000122070312,
+    datarate: [83, 70, 56, 66, 87, 49, 50, 53],
+    channel: 4,
+  } as HTTPWitnessesObject
+  if (!isValid) witnessObject = { ...witnessObject, invalid_reason: 'fake_invalid_reason'};
+  return witnessObject
+}
 
 export const mockGeocode = {
   short_street: 'fake-short_street',
@@ -128,6 +132,18 @@ describe('Challenge Model', () => {
       } as HTTPPathObject,
     ] as HTTPPathObject[]))
     expect(challenge.path[0].result).toBe(PathResult.FAILURE)
+  })
+
+  it('has invalid reason when witness is not valid', () => {
+    const challenge = new Challenge(challengeJson([
+      {
+        witnesses: [mockWitness(false)] as HTTPWitnessesObject[],
+        receipt: mockReceipt,
+        geocode: mockGeocode,
+        ...mockPathData,
+      } as HTTPPathObject,
+    ] as HTTPPathObject[]))
+    expect(challenge.path[0].witnesses[0].invalidReason).not.toBeUndefined();
   })
 
   describe('successful beacon', () => {

--- a/packages/http/src/models/__tests__/Challenge.spec.ts
+++ b/packages/http/src/models/__tests__/Challenge.spec.ts
@@ -28,23 +28,20 @@ export const mockLegacyWitness = (): HTTPWitnessesObject => ({
   channel: 4,
 } as HTTPWitnessesObject)
 
-export const mockWitness = (isValid = true): HTTPWitnessesObject => {
-  let witnessObject = {
-    timestamp: 1602013549762689800,
-    snr: 7,
-    signal: -103,
-    packet_hash: 'fake-packet_hash',
-    owner: 'fake-owner',
-    location: 'fake-location',
-    is_valid: isValid,
-    gateway: 'fake-witness-gateway',
-    frequency: 904.7000122070312,
-    datarate: [83, 70, 56, 66, 87, 49, 50, 53],
-    channel: 4,
-  } as HTTPWitnessesObject
-  if (!isValid) witnessObject = { ...witnessObject, invalid_reason: 'fake_invalid_reason'};
-  return witnessObject
-}
+export const mockWitness = (isValid = true): HTTPWitnessesObject => ({
+  timestamp: 1602013549762689800,
+  snr: 7,
+  signal: -103,
+  packet_hash: 'fake-packet_hash',
+  owner: 'fake-owner',
+  location: 'fake-location',
+  is_valid: isValid,
+  ...(!isValid && { invalid_reason: 'fake_invalid_reason' }),
+  gateway: 'fake-witness-gateway',
+  frequency: 904.7000122070312,
+  datarate: [83, 70, 56, 66, 87, 49, 50, 53],
+  channel: 4,
+})
 
 export const mockGeocode = {
   short_street: 'fake-short_street',
@@ -144,6 +141,7 @@ describe('Challenge Model', () => {
       } as HTTPPathObject,
     ] as HTTPPathObject[]))
     expect(challenge.path[0].witnesses[0].invalidReason).not.toBeUndefined();
+    expect(challenge.path[0].witnesses[0].invalidReason).toBe('fake_invalid_reason');
   })
 
   describe('successful beacon', () => {


### PR DESCRIPTION
This PR adds the new `invalid_reason` property to witnesses, so that it can be displayed on the frontend when using helium-js for anywhere witnesses show up.

I'm new to TypeScript (and Jest) so hopefully I didn't mess anything up; happy to make edits!