### PR TITLE
Use Balance for Hotspot Rewards

### DIFF
--- a/packages/currency/src/Balance.ts
+++ b/packages/currency/src/Balance.ts
@@ -1,5 +1,5 @@
 import BigNumber from 'bignumber.js'
-import CurrencyType from './CurrencyType'
+import CurrencyType, { AnyCurrencyType } from './CurrencyType'
 import {
   NetworkTokens,
   USDollars,
@@ -30,9 +30,13 @@ const DC_TO_USD_MULTIPLIER = 0.00001
 
 export default class Balance<T extends BaseCurrencyType> {
   public type: T
+
   public integerBalance: number
+
   public floatBalance: number
+
   public bigBalance: BigNumber
+
   public bigInteger: BigNumber
 
   constructor(integerBalance: number | undefined, type: T) {
@@ -41,6 +45,12 @@ export default class Balance<T extends BaseCurrencyType> {
     this.bigInteger = new BigNumber(this.integerBalance)
     this.bigBalance = this.bigInteger.times(type.coefficient)
     this.floatBalance = this.bigBalance.toNumber()
+  }
+
+  static fromFloat(float: number, currencyType: AnyCurrencyType) {
+    const bigFloat = new BigNumber(float)
+    const integerBalance = bigFloat.dividedBy(currencyType.coefficient).toNumber()
+    return new Balance(integerBalance, currencyType)
   }
 
   toString(maxDecimalPlaces?: number): string {

--- a/packages/http/src/models/HotspotReward.ts
+++ b/packages/http/src/models/HotspotReward.ts
@@ -27,7 +27,7 @@ interface HTTPHotspotRewardsSum {
 export type HotspotRewardData = HotspotReward
 
 function toBalance(floatValue: number): Balance<NetworkTokens> {
-  return new Balance(floatValue * 100000000, CurrencyType.networkToken)
+  return Balance.fromFloat(floatValue, CurrencyType.networkToken)
 }
 
 export default class HotspotReward extends DataModel {

--- a/packages/http/src/models/HotspotReward.ts
+++ b/packages/http/src/models/HotspotReward.ts
@@ -1,3 +1,4 @@
+import Balance, { CurrencyType, NetworkTokens } from '@helium/currency'
 import DataModel from './DataModel'
 import Client from '../Client'
 
@@ -25,6 +26,10 @@ interface HTTPHotspotRewardsSum {
 
 export type HotspotRewardData = HotspotReward
 
+function toBalance(floatValue: number): Balance<NetworkTokens> {
+  return new Balance(floatValue * 100000000, CurrencyType.networkToken)
+}
+
 export default class HotspotReward extends DataModel {
   private client: Client
 
@@ -32,32 +37,29 @@ export default class HotspotReward extends DataModel {
 
   public maxTime: string
 
-  public total: number
+  public total: Balance<NetworkTokens>
 
-  public sum: number
+  public stddev: Balance<NetworkTokens>
 
-  public stddev: number
+  public min: Balance<NetworkTokens>
 
-  public min: number
+  public median: Balance<NetworkTokens>
 
-  public median: number
+  public max: Balance<NetworkTokens>
 
-  public max: number
-
-  public avg: number
+  public avg: Balance<NetworkTokens>
 
   constructor(client: Client, rewards: HTTPHotspotRewardsSum) {
     super()
     this.client = client
     this.minTime = rewards.meta.min_time
     this.maxTime = rewards.meta.max_time
-    this.total = rewards.data.total
-    this.sum = rewards.data.sum
-    this.stddev = rewards.data.stddev
-    this.min = rewards.data.min
-    this.median = rewards.data.median
-    this.max = rewards.data.max
-    this.avg = rewards.data.avg
+    this.total = toBalance(rewards.data.total)
+    this.stddev = toBalance(rewards.data.stddev)
+    this.min = toBalance(rewards.data.min)
+    this.median = toBalance(rewards.data.median)
+    this.max = toBalance(rewards.data.max)
+    this.avg = toBalance(rewards.data.avg)
   }
 
   get data(): HotspotRewardsData {

--- a/packages/http/src/resources/__tests__/Hotspots.spec.ts
+++ b/packages/http/src/resources/__tests__/Hotspots.spec.ts
@@ -121,9 +121,9 @@ describe('get reward sum', () => {
     const maxTime = new Date('2020-12-18T00:00:00Z')
     const client = new Client()
     const rewards = await client.hotspot('fake-address').rewards.getSum(minTime, maxTime)
-    expect(rewards.total).toBe(13.17717245)
+    expect(rewards.total.floatBalance).toBe(13.17717245)
     expect(rewards.maxTime).toBe('2020-12-18T00:00:00Z')
-    expect(rewards.data.total).toBe(13.17717245)
+    expect(rewards.data.total.floatBalance).toBe(13.17717245)
   })
 })
 


### PR DESCRIPTION
Hotspot rewards now use Balance<NetworkToken> instead of raw numbers.