### PR TITLE
add type field to transactions

### DIFF
--- a/packages/transactions/src/AddGatewayV1.ts
+++ b/packages/transactions/src/AddGatewayV1.ts
@@ -37,6 +37,8 @@ export default class AddGatewayV1 extends Transaction {
 
   public fee?: number
 
+  public type: string = 'add_gateway_v1'
+
   constructor(opts: AddGatewayOptions) {
     super()
 

--- a/packages/transactions/src/AssertLocationV1.ts
+++ b/packages/transactions/src/AssertLocationV1.ts
@@ -43,6 +43,8 @@ export default class AssertLocationV1 extends Transaction {
 
   public nonce?: number
 
+  public type: string = 'assert_location_v1'
+
   constructor(opts: AssertLocationOptions) {
     super()
 

--- a/packages/transactions/src/PaymentV1.ts
+++ b/packages/transactions/src/PaymentV1.ts
@@ -16,11 +16,18 @@ interface SignOptions {
 
 export default class PaymentV1 extends Transaction {
   public payer?: Addressable
+
   public payee?: Addressable
+
   public amount?: number
+
   public fee?: number
+
   public nonce?: number
+
   public signature?: Uint8Array
+
+  public type: string = 'payment_v1'
 
   constructor(opts: PaymentOptions) {
     super()

--- a/packages/transactions/src/PaymentV2.ts
+++ b/packages/transactions/src/PaymentV2.ts
@@ -22,10 +22,16 @@ interface SignOptions {
 
 export default class PaymentV2 extends Transaction {
   public payer?: Addressable
+
   public payments: Array<Payment>
+
   public fee?: number
+
   public nonce?: number
+
   public signature?: Uint8Array
+
+  public type: string = 'payment_v2'
 
   constructor(opts: PaymentOptions) {
     super()

--- a/packages/transactions/src/TokenBurnV1.ts
+++ b/packages/transactions/src/TokenBurnV1.ts
@@ -20,12 +20,20 @@ interface SignOptions {
 
 export default class TokenBurnV1 extends Transaction {
   public payer: Addressable
+
   public payee: Addressable
+
   public amount: number
+
   public nonce: number
+
   public signature?: Uint8Array
+
   public fee?: number
+
   public memo: Base64Memo
+
+  public type: string = 'token_burn_v1'
 
   constructor(opts: TokenBurnOptions) {
     super()

--- a/packages/transactions/src/TransferHotspotV1.ts
+++ b/packages/transactions/src/TransferHotspotV1.ts
@@ -41,6 +41,8 @@ export default class TransferHotspotV1 extends Transaction {
 
   public fee?: number
 
+  public type: string = 'transfer_hotspot_v1'
+
   constructor(opts: TransferHotspotOptions) {
     super()
     this.gateway = opts.gateway

--- a/packages/transactions/src/__tests__/AddGatewayV1.spec.ts
+++ b/packages/transactions/src/__tests__/AddGatewayV1.spec.ts
@@ -26,6 +26,7 @@ test('create an add gateway txn', async () => {
   expect(addGw.gateway?.b58).toBe(aliceB58)
   expect(addGw.fee).toBe(45000)
   expect(addGw.stakingFee).toBe(4000000)
+  expect(addGw.type).toBe('add_gateway_v1')
 })
 
 test('create an add gateway txn with payer', async () => {

--- a/packages/transactions/src/__tests__/AssertLocationV1.spec.ts
+++ b/packages/transactions/src/__tests__/AssertLocationV1.spec.ts
@@ -33,6 +33,7 @@ test('create an assert location txn', async () => {
   expect(txn.nonce).toBe(1)
   expect(txn.fee).toBe(50000)
   expect(txn.stakingFee).toBe(1000000)
+  expect(txn.type).toBe('assert_location_v1')
 })
 
 test('create an assert location txn with a payer', async () => {

--- a/packages/transactions/src/__tests__/PaymentV1.spec.ts
+++ b/packages/transactions/src/__tests__/PaymentV1.spec.ts
@@ -31,6 +31,7 @@ test('create a payment txn', async () => {
   expect(payment.amount).toBe(10)
   expect(payment.nonce).toBe(1)
   expect(payment.fee).toBe(30000)
+  expect(payment.type).toBe('payment_v1')
 })
 
 describe('serialize', () => {

--- a/packages/transactions/src/__tests__/PaymentV2.spec.ts
+++ b/packages/transactions/src/__tests__/PaymentV2.spec.ts
@@ -37,6 +37,7 @@ test('create a PaymentV2', async () => {
   expect((payment.payments || [])[0].amount).toBe(10)
   expect(payment.nonce).toBe(1)
   expect(payment.fee).toBe(35000)
+  expect(payment.type).toBe('payment_v2')
 })
 
 describe('serialize and deserialize', () => {

--- a/packages/transactions/src/__tests__/TokenBurnV1.spec.ts
+++ b/packages/transactions/src/__tests__/TokenBurnV1.spec.ts
@@ -33,6 +33,7 @@ test('create a token burn txn', async () => {
   expect(tokenBurn.nonce).toBe(1)
   expect(tokenBurn.fee).toBe(35000)
   expect(tokenBurn.memo).toBe('MTIzNDU2Nzg5MA==')
+  expect(tokenBurn.type).toBe('token_burn_v1')
 })
 
 describe('serialize', () => {

--- a/packages/transactions/src/__tests__/TransferHotspotV1.spec.ts
+++ b/packages/transactions/src/__tests__/TransferHotspotV1.spec.ts
@@ -35,6 +35,7 @@ test('create a transfer hotspot txn', async () => {
   expect(transferHotspot.amountToSeller).toBe(10)
   expect(transferHotspot.buyerNonce).toBe(1)
   expect(transferHotspot.fee).toBe(55000)
+  expect(transferHotspot.type).toBe('transfer_hotspot_v1')
 })
 
 describe('serialize and deserialize', () => {


### PR DESCRIPTION
This adds a public `type` field to each transaction currently supported by `@helium/transactions`. These align with the `type` field returned by the API. This will make it more straightforward to create pending transactions in the app.