### PR TITLE
add NetType option to Keypair and Address

### DIFF
--- a/packages/crypto/src/Address.ts
+++ b/packages/crypto/src/Address.ts
@@ -24,7 +24,7 @@ export default class Address {
       throw new Error('unsupported version')
     }
     if (!SUPPORTED_NET_TYPES.includes(netType)) {
-      throw new Error('unsupported key tag')
+      throw new Error('unsupported net type')
     }
     if (!SUPPORTED_KEY_TYPES.includes(keyType)) {
       throw new Error('unsupported key type')

--- a/packages/crypto/src/Address.ts
+++ b/packages/crypto/src/Address.ts
@@ -1,26 +1,44 @@
-import { bs58CheckEncode, bs58KeyType, bs58Version, bs58PublicKey } from './utils'
+import {
+  bs58CheckEncode,
+  bs58KeyType,
+  bs58Version,
+  bs58PublicKey,
+  bs58NetType,
+  byteToNetType,
+  byteToKeyType,
+} from './utils'
 import { KeyType, SUPPORTED_KEY_TYPES } from './KeyType'
+import { NetType, SUPPORTED_NET_TYPES } from './NetType'
 
 export default class Address {
   public version!: number
+
+  public netType!: NetType
+
   public keyType!: KeyType
+
   public publicKey!: Uint8Array
 
-  constructor(version: number, keyType: KeyType, publicKey: Uint8Array) {
-    if (!SUPPORTED_KEY_TYPES.includes(keyType)) {
-      throw new Error('unsupported key type')
-    }
+  constructor(version: number, netType: NetType, keyType: KeyType, publicKey: Uint8Array) {
     if (version !== 0) {
       throw new Error('unsupported version')
     }
+    if (!SUPPORTED_NET_TYPES.includes(netType)) {
+      throw new Error('unsupported key tag')
+    }
+    if (!SUPPORTED_KEY_TYPES.includes(keyType)) {
+      throw new Error('unsupported key type')
+    }
     this.version = version
+    this.netType = netType
     this.keyType = keyType
     this.publicKey = publicKey
   }
 
   get bin(): Buffer {
     return Buffer.concat([
-      Buffer.from([this.keyType]),
+      // eslint-disable-next-line no-bitwise
+      Buffer.from([this.netType | this.keyType]),
       Buffer.from(this.publicKey),
     ])
   }
@@ -31,16 +49,19 @@ export default class Address {
 
   static fromB58(b58: string): Address {
     const version = bs58Version(b58)
+    const netType = bs58NetType(b58)
     const keyType = bs58KeyType(b58)
     const publicKey = bs58PublicKey(b58)
-    return new Address(version, keyType, publicKey)
+    return new Address(version, netType, keyType, publicKey)
   }
 
   static fromBin(bin: Buffer): Address {
     const version = 0
-    const keyType = bin[0]
+    const byte = bin[0]
+    const netType = byteToNetType(byte)
+    const keyType = byteToKeyType(byte)
     const publicKey = bin.slice(1, bin.length)
-    return new Address(version, keyType, publicKey)
+    return new Address(version, netType, keyType, publicKey)
   }
 
   static isValid(b58: string): boolean {

--- a/packages/crypto/src/NetType.ts
+++ b/packages/crypto/src/NetType.ts
@@ -1,0 +1,9 @@
+export const MAINNET = 0
+export const TESTNET = 0x10
+
+export const SUPPORTED_NET_TYPES = [
+  MAINNET,
+  TESTNET,
+]
+
+export type NetType = number

--- a/packages/crypto/src/NetType.ts
+++ b/packages/crypto/src/NetType.ts
@@ -1,4 +1,4 @@
-export const MAINNET = 0
+export const MAINNET = 0x00
 export const TESTNET = 0x10
 
 export const SUPPORTED_NET_TYPES = [

--- a/packages/crypto/src/__tests__/Address.spec.ts
+++ b/packages/crypto/src/__tests__/Address.spec.ts
@@ -1,17 +1,16 @@
 import { Address } from '..'
-import {
-  usersFixture,
-  bobB58,
-} from '../../../../integration_tests/fixtures/users'
+import { usersFixture, bobB58 } from '../../../../integration_tests/fixtures/users'
+import { ED25519_KEY_TYPE } from '../KeyType'
+import { MAINNET, TESTNET } from '../NetType'
 
-const ECC_COMPACT_ADDRESS =
-  '112qB3YaH5bZkCnKA5uRH7tBtGNv2Y5B4smv1jsmvGUzgKT71QpE'
+const ECC_COMPACT_ADDRESS = '112qB3YaH5bZkCnKA5uRH7tBtGNv2Y5B4smv1jsmvGUzgKT71QpE'
 const BTC_ADDRESS = '18wxa7qM8C8AXmGwJj13C7sGqn8hyFdcdR'
+const TESTNET_ADDRESS = '1bijtibPhc16wx4oJbyK8vtkAgdoRoaUvJeo7rXBnBCufEYakfd'
 
 describe('b58', () => {
   it('returns a b58 check encoded representation of the address', async () => {
     const { bob } = await usersFixture()
-    const address = new Address(0, 1, bob.publicKey)
+    const address = new Address(0, MAINNET, ED25519_KEY_TYPE, bob.publicKey)
     expect(address.b58).toBe(bobB58)
   })
 
@@ -29,7 +28,7 @@ describe('b58', () => {
 describe('bin', () => {
   it('returns a binary representation of the address', async () => {
     const { bob } = await usersFixture()
-    const address = new Address(0, 1, bob.publicKey)
+    const address = new Address(0, MAINNET, ED25519_KEY_TYPE, bob.publicKey)
     expect(address.bin[0]).toBe(1)
   })
 })
@@ -37,7 +36,7 @@ describe('bin', () => {
 describe('fromBin', () => {
   it('builds an Address from a binary representation', async () => {
     const { bob } = await usersFixture()
-    const { bin } = new Address(0, 1, bob.publicKey)
+    const { bin } = new Address(0, MAINNET, ED25519_KEY_TYPE, bob.publicKey)
     const address = Address.fromBin(bin)
     expect(address.b58).toBe(bob.address.b58)
   })
@@ -59,7 +58,7 @@ describe('unsupported key types', () => {
 
   it('throws an error if initialized with an unsupported key type', async () => {
     expect(() => {
-      new Address(0, 57, Buffer.from('some random public key'))
+      new Address(0, MAINNET, 57, Buffer.from('some random public key'))
     }).toThrow()
   })
 })
@@ -88,7 +87,14 @@ describe('unsupported versions', () => {
   it('throws an error if b58 check encoded version is not 0', async () => {
     const { bob } = await usersFixture()
     expect(() => {
-      new Address(1, 1, bob.publicKey)
+      new Address(1, MAINNET, ED25519_KEY_TYPE, bob.publicKey)
     }).toThrow()
+  })
+})
+
+describe('testnet addresses', () => {
+  it('decodes testnet addresses from b58', async () => {
+    const address = Address.fromB58(TESTNET_ADDRESS)
+    expect(address.netType).toBe(TESTNET)
   })
 })

--- a/packages/crypto/src/__tests__/Keypair.spec.ts
+++ b/packages/crypto/src/__tests__/Keypair.spec.ts
@@ -1,5 +1,7 @@
 import { Keypair, Mnemonic } from '..'
 import { bobWords, bobB58 } from '../../../../integration_tests/fixtures/users'
+import { TESTNET } from '../NetType'
+import { bs58NetType } from '../utils'
 
 describe('makeRandom', () => {
   it('makes a new random keypair', async () => {
@@ -58,7 +60,20 @@ describe('sign', () => {
     const keypair = await Keypair.fromMnemonic(mnemonic)
     const message = 'the shark feeds at midnight'
     const signature = await keypair.sign(message)
-    const expectedSignature = 'NKGpxhYtcXdyFDDRbbY5KjY7r38R8q1ViBft85t4QcH/WrB2Mg9bg2RocfYy16YGcxjLLNSwTLOmfxsjwPWdBQ=='
+    const expectedSignature =
+      'NKGpxhYtcXdyFDDRbbY5KjY7r38R8q1ViBft85t4QcH/WrB2Mg9bg2RocfYy16YGcxjLLNSwTLOmfxsjwPWdBQ=='
     expect(Buffer.from(signature).toString('base64')).toBe(expectedSignature)
+  })
+})
+
+describe('testnet keypairs', () => {
+  it('can make a testnet keypair from entropy', async () => {
+    const entropy = Buffer.from(
+      '1f5b981baca0420259ab53996df7a8ce0e3549c6616854e7dff796304bafb6bf',
+      'hex',
+    )
+    const keypair = await Keypair.fromEntropy(entropy, TESTNET)
+    expect(keypair.address.netType).toBe(TESTNET)
+    expect(bs58NetType(keypair.address.b58)).toBe(TESTNET)
   })
 })

--- a/packages/crypto/src/__tests__/Utils.spec.ts
+++ b/packages/crypto/src/__tests__/Utils.spec.ts
@@ -1,11 +1,12 @@
 import { utils, Address } from '..'
 import { bobB58, usersFixture } from '../../../../integration_tests/fixtures/users'
 import * as bs58 from 'bs58'
+import { MAINNET } from '../NetType'
 
 describe('bs58checkEncode', () => {
   it('should encode a publickey payload to b58 address', async () => {
     const { bob } = await usersFixture()
-    const address = new Address(0, 1, bob.publicKey)
+    const address = new Address(0, MAINNET, 1, bob.publicKey)
   	const vPayload = Buffer.concat([Buffer.from([0]), address.bin])
     const checksum = utils.sha256(Buffer.from(utils.sha256(vPayload)))
   	const checksumBytes = Buffer.alloc(4, checksum, 'hex')
@@ -18,7 +19,7 @@ describe('bs58checkEncode', () => {
 describe('bs58ToBin', () => {
   it('should carry a bs58 address to bin', async () => {
     const { bob } = await usersFixture()
-    const address = new Address(0, 1, bob.publicKey).b58
+    const address = new Address(0, MAINNET, 1, bob.publicKey).b58
   	const bin = bs58.decode(address)
   	const vPayload = bin.slice(0, -4)
   	const checksum = bin.slice(-4)

--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -1,4 +1,6 @@
 export { default as Mnemonic } from './Mnemonic'
 export { default as Keypair } from './Keypair'
 export { default as Address } from './Address'
+export * as NetType from './NetType'
+export * as KeyType from './KeyType'
 export * as utils from './utils'

--- a/packages/crypto/src/utils.ts
+++ b/packages/crypto/src/utils.ts
@@ -1,6 +1,9 @@
+/* eslint-disable no-bitwise */
 import createHash from 'create-hash'
 import bs58 from 'bs58'
 import sodium from 'libsodium-wrappers'
+import { NetType } from './NetType'
+import { KeyType } from './KeyType'
 
 export const randomBytes = async (n: number): Promise<Buffer> => {
   await sodium.ready
@@ -10,11 +13,7 @@ export const randomBytes = async (n: number): Promise<Buffer> => {
 export const sha256 = (buffer: Buffer | string): Buffer =>
   createHash('sha256').update(buffer).digest()
 
-export const lpad = (
-  str: string | any[],
-  padString: string,
-  length: number,
-) => {
+export const lpad = (str: string | any[], padString: string, length: number) => {
   let strOut = str
   while (strOut.length < length) strOut = padString + strOut
   return strOut
@@ -22,9 +21,7 @@ export const lpad = (
 
 export const bytesToBinary = (bytes: any[]) =>
   bytes
-    .map((x: { toString: (arg0: number) => string | any[] }) =>
-      lpad(x.toString(2), '0', 8),
-    )
+    .map((x: { toString: (arg0: number) => string | any[] }) => lpad(x.toString(2), '0', 8))
     .join('')
 
 export const binaryToByte = (bin: string) => parseInt(bin, 2)
@@ -37,10 +34,7 @@ export const deriveChecksumBits = (entropyBuffer: Buffer | string) => {
   return bytesToBinary([].slice.call(hash)).slice(0, CS)
 }
 
-export const bs58CheckEncode = (
-  version: number,
-  binary: Buffer | Uint8Array,
-): string => {
+export const bs58CheckEncode = (version: number, binary: Buffer | Uint8Array): string => {
   // VPayload = <<Version:8/unsigned-integer, Payload/binary>>,
   const vPayload = Buffer.concat([Buffer.from([version]), binary])
 
@@ -71,10 +65,19 @@ export const bs58ToBin = (bs58Address: string): Buffer => {
   return payload
 }
 
-export const bs58KeyType = (bs58Address: string): number => {
+export const byteToNetType = (byte: number): NetType => byte & 0xf0
+export const byteToKeyType = (byte: number): KeyType => byte & 0x0f
+
+export const bs58NetType = (bs58Address: string): NetType => {
   const bin = bs58ToBin(bs58Address)
-  const keyType = Buffer.from(bin).slice(0, 1)[0]
-  return keyType
+  const byte = Buffer.from(bin).slice(0, 1)[0]
+  return byteToNetType(byte)
+}
+
+export const bs58KeyType = (bs58Address: string): KeyType => {
+  const bin = bs58ToBin(bs58Address)
+  const byte = Buffer.from(bin).slice(0, 1)[0]
+  return byteToKeyType(byte)
 }
 
 export const bs58Version = (bs58Address: string): number => {


### PR DESCRIPTION
the `KeyType` byte is now used as `NetType | KeyType` where `NetType` defines a `MAINNET` or `TESTNET` key, and `KeyType` continues to specify `ED25519` vs `ECC_COMPACT`