### PR TITLE
support rewards_v2 transactions

### DIFF
--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -16,6 +16,7 @@ export {
   PaymentV1,
   PaymentV2,
   RewardsV1,
+  RewardsV2,
   AddGatewayV1,
   AssertLocationV1,
   PocReceiptsV1,

--- a/packages/http/src/models/Transaction.ts
+++ b/packages/http/src/models/Transaction.ts
@@ -234,6 +234,8 @@ export class RewardsV1 extends DataModel {
   }
 }
 
+export class RewardsV2 extends RewardsV1 {}
+
 export interface Reward {
   type: string
   gateway: string
@@ -247,6 +249,7 @@ export type AnyTransaction =
   | PaymentV1
   | PaymentV2
   | RewardsV1
+  | RewardsV2
   | AddGatewayV1
   | AssertLocationV1
   | PocReceiptsV1
@@ -319,6 +322,8 @@ export default class Transaction {
         return this.toAddGatewayV1(json)
       case 'rewards_v1':
         return this.toRewardsV1(json)
+      case 'rewards_v2':
+        return this.toRewardsV2(json)
       case 'poc_receipts_v1':
         return this.toPocReceiptsV1(json)
       case 'transfer_hotspot_v1':
@@ -390,5 +395,9 @@ export default class Transaction {
         totalAmount,
       }),
     )
+  }
+
+  static toRewardsV2(json: TxnJsonObject): RewardsV2 {
+    return this.toRewardsV1(json)
   }
 }

--- a/packages/http/src/models/__tests__/Transaction.spec.ts
+++ b/packages/http/src/models/__tests__/Transaction.spec.ts
@@ -1,4 +1,4 @@
-import Transaction, { PaymentV2, PocReceiptsV1, RewardsV1, TransferHotspotV1 } from '../Transaction'
+import Transaction, { PaymentV2, PocReceiptsV1, RewardsV1, RewardsV2, TransferHotspotV1 } from '../Transaction'
 import { HTTPPathObject, HTTPWitnessesObject } from '../Challenge'
 import {
   challengeJson,
@@ -57,6 +57,35 @@ describe('RewardsV1', () => {
       end_epoch: 300195,
     }
     const txn = Transaction.fromJsonObject(json) as RewardsV1
+    expect(txn.totalAmount.integerBalance).toBe(3000)
+  })
+})
+
+describe('RewardsV2', () => {
+  it('exposes a totalAmount balance', () => {
+    const json = {
+      type: 'rewards_v2',
+      time: 1587424041,
+      start_epoch: 300165,
+      rewards: [
+        {
+          type: 'poc_witnesses',
+          gateway: 'fake-gateway-address',
+          amount: 2000,
+          account: 'fake-owner-address',
+        },
+        {
+          type: 'poc_witnesses',
+          gateway: 'fake-gateway-address',
+          amount: 1000,
+          account: 'fake-owner-address',
+        },
+      ],
+      height: 123456,
+      hash: 'fake-txn-hash',
+      end_epoch: 300195,
+    }
+    const txn = Transaction.fromJsonObject(json) as RewardsV2
     expect(txn.totalAmount.integerBalance).toBe(3000)
   })
 })


### PR DESCRIPTION
It's my understanding that `rewards_v2` transactions will be exposed by the API in the same format as `rewards_v1` transactions. This adds support for v2 txns assuming that the json will be the same apart from a `type: 'rewards_v2'` field.