### PR TITLE
Add hotspots.elected(block)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,21 @@
 ### How to Contribute to this repository
 
+## Running helium-js locally
+1. Clone the repo and navigate into the folder
+```zsh
+git clone https://github.com/helium/helium-js.git && cd helium-js
+```
+2. Get everything installed
+```zsh
+yarn && yarn bootstrap && yarn build
+```
+3. Run the tests
+```zsh
+yarn test
+```
+If everything went well, you should see a list of green lines that say "PASS" in your terminal. That should get you up and running!
+
+## About contributing
 We value contributions from the community and will do everything we
 can go get them reviewed in a timely fashion. If you have code to send
 our way or a bug to report:

--- a/packages/http/src/resources/Hotspots.ts
+++ b/packages/http/src/resources/Hotspots.ts
@@ -60,4 +60,13 @@ export default class Hotspots {
     } = await this.client.get(url)
     return new Hotspot(this.client, hotspot)
   }
+  async elected(block: number): Promise<Hotspot[]> {
+    const url = `/elected/${block}`
+    const response = await this.client.get(url)
+    const {
+      data: { data: hotspots },
+    } = response
+    const data = hotspots.map((h: HTTPHotspotObject) => new Hotspot(this.client, h))
+    return data
+  }
 }

--- a/packages/http/src/resources/Hotspots.ts
+++ b/packages/http/src/resources/Hotspots.ts
@@ -60,8 +60,9 @@ export default class Hotspots {
     } = await this.client.get(url)
     return new Hotspot(this.client, hotspot)
   }
-  async elected(block: number): Promise<Hotspot[]> {
-    const url = `/elected/${block}`
+
+  async elected(block?: number): Promise<Hotspot[]> {
+    const url = block === undefined ? '/elected' : `/elected/${block}`
     const response = await this.client.get(url)
     const {
       data: { data: hotspots },

--- a/packages/http/src/resources/Hotspots.ts
+++ b/packages/http/src/resources/Hotspots.ts
@@ -61,13 +61,13 @@ export default class Hotspots {
     return new Hotspot(this.client, hotspot)
   }
 
-  async elected(block?: number): Promise<Hotspot[]> {
+  async elected(block?: number): Promise<ResourceList<Hotspot>> {
     const url = block === undefined ? '/elected' : `/elected/${block}`
     const response = await this.client.get(url)
     const {
       data: { data: hotspots },
     } = response
     const data = hotspots.map((h: HTTPHotspotObject) => new Hotspot(this.client, h))
-    return data
+    return new ResourceList(data, this.list.bind(this))
   }
 }

--- a/packages/http/src/resources/__tests__/Hotspots.spec.ts
+++ b/packages/http/src/resources/__tests__/Hotspots.spec.ts
@@ -179,30 +179,59 @@ describe('elected', () => {
     .get('/v1/elected/123456')
     .reply(200, {
       data: [
-        hotspotFixture({ name: 'hotspot-1' }),
-        hotspotFixture({ name: 'hotspot-2' }),
-        hotspotFixture({ name: 'hotspot-3' }),
-        hotspotFixture({ name: 'hotspot-4' }),
-        hotspotFixture({ name: 'hotspot-5' }),
-        hotspotFixture({ name: 'hotspot-6' }),
-        hotspotFixture({ name: 'hotspot-7' }),
-        hotspotFixture({ name: 'hotspot-8' }),
-        hotspotFixture({ name: 'hotspot-9' }),
-        hotspotFixture({ name: 'hotspot-10' }),
-        hotspotFixture({ name: 'hotspot-11' }),
-        hotspotFixture({ name: 'hotspot-12' }),
-        hotspotFixture({ name: 'hotspot-13' }),
-        hotspotFixture({ name: 'hotspot-14' }),
-        hotspotFixture({ name: 'hotspot-15' }),
-        hotspotFixture({ name: 'hotspot-16' }),
+        hotspotFixture({ name: 'previous-consensus-hotspot-1' }),
+        hotspotFixture({ name: 'previous-consensus-hotspot-2' }),
+        hotspotFixture({ name: 'previous-consensus-hotspot-3' }),
+        hotspotFixture({ name: 'previous-consensus-hotspot-4' }),
+        hotspotFixture({ name: 'previous-consensus-hotspot-5' }),
+        hotspotFixture({ name: 'previous-consensus-hotspot-6' }),
+        hotspotFixture({ name: 'previous-consensus-hotspot-7' }),
+        hotspotFixture({ name: 'previous-consensus-hotspot-8' }),
+        hotspotFixture({ name: 'previous-consensus-hotspot-9' }),
+        hotspotFixture({ name: 'previous-consensus-hotspot-10' }),
+        hotspotFixture({ name: 'previous-consensus-hotspot-11' }),
+        hotspotFixture({ name: 'previous-consensus-hotspot-12' }),
+        hotspotFixture({ name: 'previous-consensus-hotspot-13' }),
+        hotspotFixture({ name: 'previous-consensus-hotspot-14' }),
+        hotspotFixture({ name: 'previous-consensus-hotspot-15' }),
+        hotspotFixture({ name: 'previous-consensus-hotspot-16' }),
+      ],
+    })
+  nock('https://api.helium.io')
+    .get('/v1/elected')
+    .reply(200, {
+      data: [
+        hotspotFixture({ name: 'current-consensus-hotspot-1' }),
+        hotspotFixture({ name: 'current-consensus-hotspot-2' }),
+        hotspotFixture({ name: 'current-consensus-hotspot-3' }),
+        hotspotFixture({ name: 'current-consensus-hotspot-4' }),
+        hotspotFixture({ name: 'current-consensus-hotspot-5' }),
+        hotspotFixture({ name: 'current-consensus-hotspot-6' }),
+        hotspotFixture({ name: 'current-consensus-hotspot-7' }),
+        hotspotFixture({ name: 'current-consensus-hotspot-8' }),
+        hotspotFixture({ name: 'current-consensus-hotspot-9' }),
+        hotspotFixture({ name: 'current-consensus-hotspot-10' }),
+        hotspotFixture({ name: 'current-consensus-hotspot-11' }),
+        hotspotFixture({ name: 'current-consensus-hotspot-12' }),
+        hotspotFixture({ name: 'current-consensus-hotspot-13' }),
+        hotspotFixture({ name: 'current-consensus-hotspot-14' }),
+        hotspotFixture({ name: 'current-consensus-hotspot-15' }),
+        hotspotFixture({ name: 'current-consensus-hotspot-16' }),
       ],
     })
 
   it('retrieves elected hotspots at a given block height', async () => {
     const client = new Client()
     const elected = await client.hotspots.elected(123456)
-    expect(elected[15].name).toBe('hotspot-16')
-    expect(elected.length).toBe(16)
+    expect(elected[0].name).toBe('previous-consensus-hotspot-1')
+    expect(elected[elected.length - 1].name).toBe('previous-consensus-hotspot-16')
+  })
+
+  it('retrieves currently elected hotspots', async () => {
+    const client = new Client()
+    const elected = await client.hotspots.elected()
+    expect(elected[0].name).toBe('current-consensus-hotspot-1')
+    expect(elected[elected.length - 1].name).toBe('current-consensus-hotspot-16')
   })
 })
 

--- a/packages/http/src/resources/__tests__/Hotspots.spec.ts
+++ b/packages/http/src/resources/__tests__/Hotspots.spec.ts
@@ -222,14 +222,18 @@ describe('elected', () => {
 
   it('retrieves elected hotspots at a given block height', async () => {
     const client = new Client()
-    const elected = await client.hotspots.elected(123456)
+    const list = await client.hotspots.elected(123456)
+    const elected = await list.take(16)
+    expect(elected.length).toBe(16)
     expect(elected[0].name).toBe('previous-consensus-hotspot-1')
     expect(elected[elected.length - 1].name).toBe('previous-consensus-hotspot-16')
   })
 
   it('retrieves currently elected hotspots', async () => {
     const client = new Client()
-    const elected = await client.hotspots.elected()
+    const list = await client.hotspots.elected()
+    const elected = await list.take(16)
+    expect(elected.length).toBe(16)
     expect(elected[0].name).toBe('current-consensus-hotspot-1')
     expect(elected[elected.length - 1].name).toBe('current-consensus-hotspot-16')
   })

--- a/packages/http/src/resources/__tests__/Hotspots.spec.ts
+++ b/packages/http/src/resources/__tests__/Hotspots.spec.ts
@@ -118,15 +118,17 @@ export const rewardSumListFixture = () => ({
     min_time: '2020-12-17T00:00:00Z',
     max_time: '2020-12-18T00:00:00Z',
   },
-  data: [{
-    total: 13.17717245,
-    sum: 1317717245,
-    stddev: 1.10445133,
-    min: 0,
-    median: 1.98726309,
-    max: 2,
-    avg: 1.4641302722222223,
-  }],
+  data: [
+    {
+      total: 13.17717245,
+      sum: 1317717245,
+      stddev: 1.10445133,
+      min: 0,
+      median: 1.98726309,
+      max: 2,
+      avg: 1.4641302722222223,
+    },
+  ],
 })
 
 export const rewardsFixture = () => ({
@@ -169,6 +171,38 @@ describe('get', () => {
     expect(hotspot.name).toBe('some-hotspot-name')
     expect(hotspot.timestampAdded).toBe('2020-11-24T02:52:12.000000Z')
     expect(hotspot.rewardScale).toBe(0.07049560546875)
+  })
+})
+
+describe('elected', () => {
+  nock('https://api.helium.io')
+    .get('/v1/elected/123456')
+    .reply(200, {
+      data: [
+        hotspotFixture({ name: 'hotspot-1' }),
+        hotspotFixture({ name: 'hotspot-2' }),
+        hotspotFixture({ name: 'hotspot-3' }),
+        hotspotFixture({ name: 'hotspot-4' }),
+        hotspotFixture({ name: 'hotspot-5' }),
+        hotspotFixture({ name: 'hotspot-6' }),
+        hotspotFixture({ name: 'hotspot-7' }),
+        hotspotFixture({ name: 'hotspot-8' }),
+        hotspotFixture({ name: 'hotspot-9' }),
+        hotspotFixture({ name: 'hotspot-10' }),
+        hotspotFixture({ name: 'hotspot-11' }),
+        hotspotFixture({ name: 'hotspot-12' }),
+        hotspotFixture({ name: 'hotspot-13' }),
+        hotspotFixture({ name: 'hotspot-14' }),
+        hotspotFixture({ name: 'hotspot-15' }),
+        hotspotFixture({ name: 'hotspot-16' }),
+      ],
+    })
+
+  it('retrieves elected hotspots at a given block height', async () => {
+    const client = new Client()
+    const elected = await client.hotspots.elected(123456)
+    expect(elected[15].name).toBe('hotspot-16')
+    expect(elected.length).toBe(16)
   })
 })
 
@@ -220,7 +254,9 @@ describe('list witnesses', () => {
     })
 
   nock('https://api.helium.io')
-    .get('/v1/hotspots/fake-address/witnesses/sum?min_time=2020-12-17T00%3A00%3A00.000Z&max_time=2020-12-18T00%3A00%3A00.000Z&bucket=week')
+    .get(
+      '/v1/hotspots/fake-address/witnesses/sum?min_time=2020-12-17T00%3A00%3A00.000Z&max_time=2020-12-18T00%3A00%3A00.000Z&bucket=week',
+    )
     .reply(200, witnessSumFixture())
 
   nock('https://api.helium.io')
@@ -237,7 +273,9 @@ describe('list witnesses', () => {
 
   it('lists hotspot witness sums with date time', async () => {
     const client = new Client()
-    const list = await client.hotspot('fake-address').witnesses.sum.list({ minTime: '-30 day', bucket: 'week' })
+    const list = await client
+      .hotspot('fake-address')
+      .witnesses.sum.list({ minTime: '-30 day', bucket: 'week' })
     const witnessSums = await list.take(4)
     expect(witnessSums.length).toBe(4)
     expect(witnessSums[0].max).toBe(9)
@@ -247,7 +285,9 @@ describe('list witnesses', () => {
     const client = new Client()
     const minTime = new Date('2020-12-17T00:00:00Z')
     const maxTime = new Date('2020-12-18T00:00:00Z')
-    const list = await client.hotspot('fake-address').witnesses.sum.list({ minTime, maxTime, bucket: 'week' })
+    const list = await client
+      .hotspot('fake-address')
+      .witnesses.sum.list({ minTime, maxTime, bucket: 'week' })
     const witnessSums = await list.take(4)
     expect(witnessSums.length).toBe(4)
     expect(witnessSums[0].max).toBe(9)
@@ -256,15 +296,21 @@ describe('list witnesses', () => {
 
 describe('get rewards', () => {
   nock('https://api.helium.io')
-    .get('/v1/hotspots/fake-address/rewards/sum?min_time=2020-12-17T00%3A00%3A00.000Z&max_time=2020-12-18T00%3A00%3A00.000Z')
+    .get(
+      '/v1/hotspots/fake-address/rewards/sum?min_time=2020-12-17T00%3A00%3A00.000Z&max_time=2020-12-18T00%3A00%3A00.000Z',
+    )
     .reply(200, rewardSumFixture())
 
   nock('https://api.helium.io')
-    .get('/v1/hotspots/fake-address/rewards?min_time=2020-12-17T00%3A00%3A00.000Z&max_time=2020-12-18T00%3A00%3A00.000Z')
+    .get(
+      '/v1/hotspots/fake-address/rewards?min_time=2020-12-17T00%3A00%3A00.000Z&max_time=2020-12-18T00%3A00%3A00.000Z',
+    )
     .reply(200, rewardsFixture())
 
   nock('https://api.helium.io')
-    .get('/v1/hotspots/fake-address/rewards/sum?min_time=2020-12-17T00%3A00%3A00.000Z&max_time=2020-12-18T00%3A00%3A00.000Z&bucket=day')
+    .get(
+      '/v1/hotspots/fake-address/rewards/sum?min_time=2020-12-17T00%3A00%3A00.000Z&max_time=2020-12-18T00%3A00%3A00.000Z&bucket=day',
+    )
     .reply(200, rewardSumListFixture())
 
   nock('https://api.helium.io')
@@ -310,7 +356,9 @@ describe('get rewards', () => {
     const minTime = new Date('2020-12-17T00:00:00Z')
     const maxTime = new Date('2020-12-18T00:00:00Z')
     const client = new Client()
-    const rewardsList = await client.hotspot('fake-address').rewards.sum.list({ minTime, maxTime, bucket: 'day' })
+    const rewardsList = await client
+      .hotspot('fake-address')
+      .rewards.sum.list({ minTime, maxTime, bucket: 'day' })
     const rewards = await rewardsList.take(5)
     expect(rewards.length).toBe(1)
     expect(rewards[0].balanceTotal.floatBalance).toBe(13.17717245)
@@ -320,7 +368,9 @@ describe('get rewards', () => {
   it('list hotspot reward sums by bucket', async () => {
     const minTime = '-1 day'
     const client = new Client()
-    const rewardsList = await client.hotspot('fake-address').rewards.sum.list({ minTime, bucket: 'day' })
+    const rewardsList = await client
+      .hotspot('fake-address')
+      .rewards.sum.list({ minTime, bucket: 'day' })
     const rewards = await rewardsList.take(5)
     expect(rewards.length).toBe(1)
     expect(rewards[0].balanceTotal.floatBalance).toBe(13.17717245)
@@ -364,14 +414,13 @@ describe('challenges', () => {
   nock('https://api.helium.io')
     .get('/v1/hotspots/fake-address/challenges')
     .reply(200, {
-      data: [
-        challengeFixture({ hash: 'fake-hash-1' }),
-        challengeFixture({ hash: 'fake-hash-2' }),
-      ],
+      data: [challengeFixture({ hash: 'fake-hash-1' }), challengeFixture({ hash: 'fake-hash-2' })],
     })
 
   nock('https://api.helium.io')
-    .get('/v1/hotspots/fake-address/challenges/sum?min_time=2020-12-17T00%3A00%3A00.000Z&max_time=2020-12-18T00%3A00%3A00.000Z&bucket=day')
+    .get(
+      '/v1/hotspots/fake-address/challenges/sum?min_time=2020-12-17T00%3A00%3A00.000Z&max_time=2020-12-18T00%3A00%3A00.000Z&bucket=day',
+    )
     .reply(200, challengeSumListFixture())
 
   it('list challenges from hotspot', async () => {
@@ -386,7 +435,9 @@ describe('challenges', () => {
     const minTime = new Date('2020-12-17T00:00:00Z')
     const maxTime = new Date('2020-12-18T00:00:00Z')
     const client = new Client()
-    const list = await client.hotspot('fake-address').challenges.sum.list({ minTime, maxTime, bucket: 'day' })
+    const list = await client
+      .hotspot('fake-address')
+      .challenges.sum.list({ minTime, maxTime, bucket: 'day' })
     const challenges = await list.take(2)
     expect(challenges[0].sum).toBe(40)
     expect(challenges[1].sum).toBe(37)


### PR DESCRIPTION
Adds `client.hotspots.elected(block)` for hotspots elected at a given block height, and `client.hotspots.elected()` for currently elected hotspots

Seems to pass the tests:
```sh
  elected
    ✓ retrieves elected hotspots at a given block height (6 ms)
    ✓ retrieves currently elected hotspots (5 ms)
```