### PR TITLE
Assert V2 Fix

### DIFF
--- a/packages/transactions/src/AssertLocationV2.ts
+++ b/packages/transactions/src/AssertLocationV2.ts
@@ -168,7 +168,7 @@ export default class AssertLocationV2 extends Transaction {
       location: this.location,
       nonce: this.nonce,
       gain: this.gain,
-      elevation: this.elevation,
+      elevation: this.elevation && this.elevation > 0 ? this.elevation : null,
       fee: this.fee && this.fee > 0 ? this.fee : null,
       stakingFee: this.stakingFee && this.stakingFee > 0 ? this.stakingFee : null,
       ownerSignature: this.ownerSignature && !forSigning ? toUint8Array(this.ownerSignature) : null,


### PR DESCRIPTION
Send 0 elevation as null in assert v2 proto.

We need to make sure we send any 0 values as null or the signatures don't line up with what the blockchain expects