### PR TITLE
assert v2 support in http

### DIFF
--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -19,6 +19,7 @@ export {
   RewardsV2,
   AddGatewayV1,
   AssertLocationV1,
+  AssertLocationV2,
   PocReceiptsV1,
   TransferHotspotV1,
   TokenBurnV1,

--- a/packages/http/src/models/Hotspot.ts
+++ b/packages/http/src/models/Hotspot.ts
@@ -30,6 +30,8 @@ export interface HTTPHotspotObject {
   timestamp_added?: string
   last_poc_challenge?: number
   last_change_block?: number
+  gain?: number
+  elevation?: number
 }
 
 interface HTTPGeocodeObject {
@@ -97,6 +99,10 @@ export default class Hotspot extends DataModel {
 
   public lastChangeBlock?: number
 
+  public gain?: number
+
+  public elevation?: number
+
   constructor(client: Client, hotspot: HTTPHotspotObject) {
     super()
     this.client = client
@@ -115,6 +121,8 @@ export default class Hotspot extends DataModel {
     this.timestampAdded = hotspot.timestamp_added
     this.lastPocChallenge = hotspot.last_poc_challenge
     this.lastChangeBlock = hotspot.last_change_block
+    this.gain = hotspot.gain
+    this.elevation = hotspot.elevation
     if (hotspot.geocode) {
       this.geocode = camelcaseKeys(hotspot.geocode) as any
     }

--- a/packages/http/src/models/Transaction.ts
+++ b/packages/http/src/models/Transaction.ts
@@ -125,6 +125,51 @@ export class AssertLocationV1 extends DataModel {
   }
 }
 
+export class AssertLocationV2 extends DataModel {
+  type!: string
+
+  time!: number
+
+  stakingFee!: Balance<DataCredits>
+
+  payerSignature!: string
+
+  payer!: string
+
+  ownerSignature!: string
+
+  owner!: string
+
+  nonce!: number
+
+  location!: string
+
+  lng!: number
+
+  lat!: number
+
+  height!: number
+
+  hash!: string
+
+  gateway!: string
+
+  gain!: number
+
+  fee!: Balance<DataCredits>
+
+  elevation!: number
+
+  constructor(data: AssertLocationV2) {
+    super()
+    Object.assign(this, data)
+  }
+
+  get data(): AssertLocationV2 {
+    return this
+  }
+}
+
 export class PaymentV1 extends DataModel {
   type!: string
 
@@ -330,6 +375,8 @@ export default class Transaction {
         return this.toTransferHotspotV1(json)
       case 'assert_location_v1':
         return this.toAssertLocationV1(json)
+      case 'assert_location_v2':
+        return this.toAssertLocationV2(json)
       case 'token_burn_v1':
         return this.toTokenBurnV1(json)
       default:
@@ -363,6 +410,10 @@ export default class Transaction {
 
   static toAssertLocationV1(json: TxnJsonObject): AssertLocationV1 {
     return new AssertLocationV1(prepareTxn(json))
+  }
+
+  static toAssertLocationV2(json: TxnJsonObject): AssertLocationV2 {
+    return new AssertLocationV2(prepareTxn(json))
   }
 
   static toTokenBurnV1(json: TxnJsonObject): TokenBurnV1 {

--- a/packages/http/src/resources/__tests__/Hotspots.spec.ts
+++ b/packages/http/src/resources/__tests__/Hotspots.spec.ts
@@ -27,6 +27,8 @@ export const hotspotFixture = (params = {}) => ({
   last_poc_challenge: 213456,
   last_change_block: 213456,
   address: 'fake-hotspot-address',
+  gain: 12,
+  elevation: 3,
   ...params,
 })
 

--- a/packages/http/src/resources/__tests__/Transactions.spec.ts
+++ b/packages/http/src/resources/__tests__/Transactions.spec.ts
@@ -263,13 +263,16 @@ describe('list from hotspot', () => {
     expect(txn4 instanceof AssertLocationV2).toBeTruthy()
 
     expect((txn0 as AssertLocationV1).hash).toBe('fake-hash-1')
+    expect((txn0 as AssertLocationV1).data.hash).toBe('fake-hash-1')
     expect((txn1 as AddGatewayV1).hash).toBe('fake-hash-2')
+    expect((txn1 as AddGatewayV1).data.hash).toBe('fake-hash-2')
     expect((txn1 as AddGatewayV1).stakingFee.toDataCredits().toString()).toBe('1 DC')
     expect((txn2 as UnknownTransaction).time).toBe(1587299256)
     expect((txn3 as TokenBurnV1).fee.toDataCredits().toString()).toBe('35,000 DC')
     expect((txn4 as AssertLocationV2).hash).toBe('fake-hash-4')
     expect((txn4 as AssertLocationV2).gain).toBe(12)
     expect((txn4 as AssertLocationV2).elevation).toBe(0)
+    expect((txn4 as AssertLocationV2).data.elevation).toBe(0)
   })
 })
 

--- a/packages/http/src/resources/__tests__/Transactions.spec.ts
+++ b/packages/http/src/resources/__tests__/Transactions.spec.ts
@@ -6,6 +6,7 @@ import {
   AssertLocationV1,
   AddGatewayV1,
   TokenBurnV1,
+  AssertLocationV2,
 } from '../../index'
 
 describe('submit', () => {
@@ -226,27 +227,49 @@ describe('list from hotspot', () => {
           fee: 35000,
           amount: 500000000000,
         },
+        {
+          type: 'assert_location_v2',
+          time: 1587251449,
+          staking_fee: 1,
+          payer: 'fake-payer-address',
+          owner: 'fake-owner-addres',
+          nonce: 1,
+          location: 'fake-h3-location',
+          lng: -123.03528172874591,
+          lat: 40.82000831418664,
+          height: 100000,
+          hash: 'fake-hash-4',
+          gateway: 'fake-gateway',
+          gain: 12,
+          fee: 0,
+          elevation: 0,
+        },
       ],
     })
 
   it('lists transaction activity for an account', async () => {
     const client = new Client()
     const list = await client.hotspot('fake-hotspot-address').activity.list()
-    const txns = await list.take(4)
+    const txns = await list.take(5)
     const txn0 = txns[0]
     const txn1 = txns[1]
     const txn2 = txns[2]
     const txn3 = txns[3]
+    const txn4 = txns[4]
     expect(txn0 instanceof AssertLocationV1).toBeTruthy()
     expect(txn1 instanceof AddGatewayV1).toBeTruthy()
     expect(txn2 instanceof UnknownTransaction).toBeTruthy()
     expect(txn3 instanceof TokenBurnV1).toBeTruthy()
+    expect(txn4 instanceof AssertLocationV2).toBeTruthy()
 
     expect((txn0 as AssertLocationV1).hash).toBe('fake-hash-1')
     expect((txn1 as AddGatewayV1).hash).toBe('fake-hash-2')
     expect((txn1 as AddGatewayV1).stakingFee.toDataCredits().toString()).toBe('1 DC')
     expect((txn2 as UnknownTransaction).time).toBe(1587299256)
     expect((txn3 as TokenBurnV1).fee.toDataCredits().toString()).toBe('35,000 DC')
+    expect((txn4 as AssertLocationV2).hash).toBe('fake-hash-4')
+    expect((txn4 as AssertLocationV2).gain).toBe(12)
+    expect((txn4 as AssertLocationV2).elevation).toBe(0)
   })
 })
 

--- a/packages/transactions/src/AssertLocationV2.ts
+++ b/packages/transactions/src/AssertLocationV2.ts
@@ -168,7 +168,7 @@ export default class AssertLocationV2 extends Transaction {
       location: this.location,
       nonce: this.nonce,
       gain: this.gain,
-      elevation: this.elevation,
+      elevation: this.elevation && this.elevation > 0 ? this.elevation : null,
       fee: this.fee && this.fee > 0 ? this.fee : null,
       stakingFee: this.stakingFee && this.stakingFee > 0 ? this.stakingFee : null,
       ownerSignature: this.ownerSignature && !forSigning ? toUint8Array(this.ownerSignature) : null,


### PR DESCRIPTION
Adds assert v2 support to @helium/http. Once https://github.com/helium/blockchain-http/issues/208 is done there will be a couple more changes to add.