### PR TITLE
add witness info to witness model

### DIFF
--- a/packages/http/src/models/Witness.ts
+++ b/packages/http/src/models/Witness.ts
@@ -1,0 +1,177 @@
+import camelcaseKeys from 'camelcase-keys'
+import type Client from '../Client'
+import DataModel from './DataModel'
+
+export type WitnessData = Omit<Witness, 'client'>
+
+export type Bucket = 'hour' | 'day' | 'week'
+
+export type NaturalDate = `-${number} ${Bucket}`
+
+export interface HTTPWitnessObject {
+  score_update_height?: number
+  score?: number
+  reward_scale?: number
+  owner?: string
+  name?: string
+  location?: string
+  lng?: number
+  lat?: number
+  block?: number
+  block_added?: number
+  geocode?: HTTPGeocodeObject
+  address: string
+  status?: Status
+  nonce?: number
+  timestamp_added?: string
+  last_poc_challenge?: number
+  last_change_block?: number
+  gain?: number
+  elevation?: number
+  witness_for?: string
+  witness_info?: HTTPWitnessInfoObject
+}
+
+interface HTTPWitnessInfoObject {
+  recent_time?: number
+  histogram?: {
+    '28'?: number
+    '-92'?: number
+    '-84'?: number
+    '-76'?: number
+    '-68'?: number
+    '-60'?: number
+    '-132'?: number
+    '-124'?: number
+    '-116'?: number
+    '-108'?: number
+    '-100'?: number
+  }
+  first_time?: number
+}
+
+interface WitnessInfo {
+  recentTime?: number
+  histogram?: {
+    '28'?: number
+    '-92'?: number
+    '-84'?: number
+    '-76'?: number
+    '-68'?: number
+    '-60'?: number
+    '-132'?: number
+    '-124'?: number
+    '-116'?: number
+    '-108'?: number
+    '-100'?: number
+  }
+  firstTime?: number
+}
+
+interface HTTPGeocodeObject {
+  short_street: string
+  short_state: string
+  short_country: string
+  short_city: string
+  long_street: string
+  long_state: string
+  long_country: string
+  long_city: string
+}
+
+interface Geocode {
+  shortStreet: string
+  shortState: string
+  shortCountry: string
+  shortCity: string
+  longStreet: string
+  longState: string
+  longCountry: string
+  longCity: string
+}
+
+interface Status {
+  gps: string
+  height: number
+  online: string
+}
+
+export default class Witness extends DataModel {
+  private client: Client
+
+  public scoreUpdateHeight?: number
+
+  public score?: number
+
+  public rewardScale?: number
+
+  public owner?: string
+
+  public name?: string
+
+  public location?: string
+
+  public lng?: number
+
+  public lat?: number
+
+  public block?: number
+
+  public geocode?: Geocode
+
+  public address: string
+
+  public status?: Status
+
+  public nonce?: number
+
+  public blockAdded?: number
+
+  public timestampAdded?: string
+
+  public lastPocChallenge?: number
+
+  public lastChangeBlock?: number
+
+  public gain?: number
+
+  public elevation?: number
+
+  public witnessFor?: string
+
+  public witnessInfo?: WitnessInfo
+
+  constructor(client: Client, witness: HTTPWitnessObject) {
+    super()
+    this.client = client
+    this.scoreUpdateHeight = witness.score_update_height
+    this.score = witness.score
+    this.rewardScale = witness.reward_scale
+    this.owner = witness.owner
+    this.name = witness.name
+    this.location = witness.location
+    this.lng = witness.lng
+    this.lat = witness.lat
+    this.block = witness.block
+    this.status = witness.status
+    this.nonce = witness.nonce
+    this.blockAdded = witness.block_added
+    this.timestampAdded = witness.timestamp_added
+    this.lastPocChallenge = witness.last_poc_challenge
+    this.lastChangeBlock = witness.last_change_block
+    this.gain = witness.gain
+    this.elevation = witness.elevation
+    if (witness.geocode) {
+      this.geocode = camelcaseKeys(witness.geocode) as any
+    }
+    this.address = witness.address
+    this.witnessFor = witness.witness_for
+    this.witnessInfo = witness.witness_info
+  }
+
+  get data(): WitnessData {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { client, ...rest } = this
+    return { ...rest }
+  }
+}

--- a/packages/http/src/models/Witness.ts
+++ b/packages/http/src/models/Witness.ts
@@ -33,7 +33,7 @@ export interface HTTPWitnessObject {
 }
 
 interface HTTPWitnessInfoObject {
-  recent_time?: number
+  recent_time?: string
   histogram?: {
     '28'?: number
     '-92'?: number
@@ -47,11 +47,11 @@ interface HTTPWitnessInfoObject {
     '-108'?: number
     '-100'?: number
   }
-  first_time?: number
+  first_time?: string
 }
 
 interface WitnessInfo {
-  recentTime?: number
+  recentTime?: string
   histogram?: {
     '28'?: number
     '-92'?: number
@@ -65,7 +65,7 @@ interface WitnessInfo {
     '-108'?: number
     '-100'?: number
   }
-  firstTime?: number
+  firstTime?: string
 }
 
 interface HTTPGeocodeObject {
@@ -166,7 +166,9 @@ export default class Witness extends DataModel {
     }
     this.address = witness.address
     this.witnessFor = witness.witness_for
-    this.witnessInfo = witness.witness_info
+    if (witness.witness_info) {
+      this.witnessInfo = camelcaseKeys(witness.witness_info) as any
+    }
   }
 
   get data(): WitnessData {

--- a/packages/http/src/resources/Hotspots.ts
+++ b/packages/http/src/resources/Hotspots.ts
@@ -8,7 +8,7 @@ interface ListParams {
   cursor?: string
 }
 
-type Context = Account | City | Hotspot
+type Context = Account | City
 
 export default class Hotspots {
   private client!: Client
@@ -51,10 +51,6 @@ export default class Hotspots {
     if (this.context instanceof City) {
       const city = this.context as City
       url = `/cities/${city.cityId}/hotspots`
-    }
-    if (this.context instanceof Hotspot) {
-      const hotspot = this.context as Hotspot
-      url = `/hotspots/${hotspot.address}/witnesses`
     }
     const response = await this.client.get(url, { cursor: params.cursor })
     const {

--- a/packages/http/src/resources/Witnesses.ts
+++ b/packages/http/src/resources/Witnesses.ts
@@ -1,8 +1,8 @@
 import type Client from '../Client'
 import ResourceList from '../ResourceList'
-import Hotspot from '../models/Hotspot'
-import Hotspots from './Hotspots'
 import Sums, { SumsType } from './Sums'
+import Hotspot from '../models/Hotspot'
+import Witness, { HTTPWitnessObject } from '../models/Witness'
 
 interface ListParams {
   cursor?: string
@@ -18,9 +18,13 @@ export default class Witnesses {
     this.hotspot = hotspot
   }
 
-  async list(params: ListParams = {}): Promise<ResourceList<Hotspot>> {
-    const hotspots = new Hotspots(this.client, this.hotspot)
-    return hotspots.list(params)
+  async list(params: ListParams = {}): Promise<ResourceList<Witness>> {
+    const url = `/hotspots/${this.hotspot.address}/witnesses`
+    const {
+      data: { data: witnesses, cursor },
+    } = await this.client.get(url, { cursor: params.cursor })
+    const data = witnesses.map((witness: HTTPWitnessObject) => new Witness(this.client, witness))
+    return new ResourceList(data, this.list.bind(this), cursor)
   }
 
   public get sum() {

--- a/packages/http/src/resources/__tests__/Hotspots.spec.ts
+++ b/packages/http/src/resources/__tests__/Hotspots.spec.ts
@@ -32,48 +32,6 @@ export const hotspotFixture = (params = {}) => ({
   ...params,
 })
 
-export const witnessSumFixture = () => ({
-  meta: {
-    min_time: '2021-01-04T21:55:18Z',
-    max_time: '2021-02-03T21:55:18Z',
-    bucket: 'week',
-  },
-  data: [
-    {
-      timestamp: '2021-01-27T21:55:18.000000Z',
-      stddev: 0.7387766471133708,
-      min: 7,
-      median: 9,
-      max: 9,
-      avg: 8.382978723404255,
-    },
-    {
-      timestamp: '2021-01-20T21:55:18.000000Z',
-      stddev: 3.327131676805893,
-      min: 0,
-      median: 6,
-      max: 12,
-      avg: 4.946428571428571,
-    },
-    {
-      timestamp: '2021-01-13T21:55:18.000000Z',
-      stddev: 0.8293691019953858,
-      min: 10,
-      median: 12,
-      max: 12,
-      avg: 11.416666666666666,
-    },
-    {
-      timestamp: '2021-01-06T21:55:18.000000Z',
-      stddev: 0.4562439130098156,
-      min: 9,
-      median: 10,
-      max: 10,
-      avg: 9.712121212121213,
-    },
-  ],
-})
-
 export const rewardSumFixture = () => ({
   meta: {
     min_time: '2020-12-17T00:00:00Z',
@@ -299,54 +257,6 @@ describe('search by hotspot name', () => {
     const hotspots = await list.take(2)
     expect(hotspots[0].name).toBe('chicken-burrito-guacamole')
     expect(hotspots[1].name).toBe('chicken-burrito-salsa')
-  })
-})
-
-describe('list witnesses', () => {
-  nock('https://api.helium.io')
-    .get('/v1/hotspots/fake-address/witnesses')
-    .reply(200, {
-      data: [hotspotFixture({ name: 'hotspot-1' }), hotspotFixture({ name: 'hotspot-2' })],
-    })
-
-  nock('https://api.helium.io')
-    .get(
-      '/v1/hotspots/fake-address/witnesses/sum?min_time=2020-12-17T00%3A00%3A00.000Z&max_time=2020-12-18T00%3A00%3A00.000Z&bucket=week',
-    )
-    .reply(200, witnessSumFixture())
-
-  nock('https://api.helium.io')
-    .get('/v1/hotspots/fake-address/witnesses/sum?min_time=-30%20day&bucket=week')
-    .reply(200, witnessSumFixture())
-
-  it('lists hotspots witnesses', async () => {
-    const client = new Client()
-    const list = await client.hotspot('fake-address').witnesses.list()
-    const hotspots = await list.take(2)
-    expect(hotspots[0].name).toBe('hotspot-1')
-    expect(hotspots[1].name).toBe('hotspot-2')
-  })
-
-  it('lists hotspot witness sums with date time', async () => {
-    const client = new Client()
-    const list = await client
-      .hotspot('fake-address')
-      .witnesses.sum.list({ minTime: '-30 day', bucket: 'week' })
-    const witnessSums = await list.take(4)
-    expect(witnessSums.length).toBe(4)
-    expect(witnessSums[0].max).toBe(9)
-  })
-
-  it('lists hotspot witness sums with string time', async () => {
-    const client = new Client()
-    const minTime = new Date('2020-12-17T00:00:00Z')
-    const maxTime = new Date('2020-12-18T00:00:00Z')
-    const list = await client
-      .hotspot('fake-address')
-      .witnesses.sum.list({ minTime, maxTime, bucket: 'week' })
-    const witnessSums = await list.take(4)
-    expect(witnessSums.length).toBe(4)
-    expect(witnessSums[0].max).toBe(9)
   })
 })
 

--- a/packages/http/src/resources/__tests__/Witnesses.spec.ts
+++ b/packages/http/src/resources/__tests__/Witnesses.spec.ts
@@ -1,0 +1,141 @@
+import nock from 'nock'
+import Client from '../../Client'
+
+export const witnessFixture = (params = {}) => ({
+  score_update_height: 213456,
+  score: 0.25,
+  reward_scale: 0.07049560546875,
+  owner: 'fake-owner-address',
+  name: 'some-hotspot-name',
+  location: 'an-h3-address',
+  lng: -123.03528172874591,
+  lat: 55.82000831418664,
+  geocode: {
+    short_street: 'Market St',
+    short_state: 'CA',
+    short_country: 'US',
+    short_city: 'San Francisco',
+    long_street: 'Market Street',
+    long_state: 'California',
+    long_country: 'United States',
+    long_city: 'San Francisco',
+  },
+  block: 123456,
+  timestamp_added: '2020-11-24T02:52:12.000000Z',
+  last_poc_challenge: 213456,
+  last_change_block: 213456,
+  address: 'fake-hotspot-address',
+  gain: 12,
+  elevation: 3,
+  witness_info: {
+    recent_time: 1618969231803488000,
+    histogram: {
+      '28': 0,
+      '-92': 21,
+      '-84': 9,
+      '-76': 0,
+      '-68': 0,
+      '-60': 0,
+      '-132': 0,
+      '-124': 0,
+      '-116': 0,
+      '-108': 0,
+      '-100': 1,
+    },
+    first_time: 1618163719840575700,
+  },
+  witness_for: 'fake-witness-for-address',
+  ...params,
+})
+
+export const witnessSumFixture = () => ({
+  meta: {
+    min_time: '2021-01-04T21:55:18Z',
+    max_time: '2021-02-03T21:55:18Z',
+    bucket: 'week',
+  },
+  data: [
+    {
+      timestamp: '2021-01-27T21:55:18.000000Z',
+      stddev: 0.7387766471133708,
+      min: 7,
+      median: 9,
+      max: 9,
+      avg: 8.382978723404255,
+    },
+    {
+      timestamp: '2021-01-20T21:55:18.000000Z',
+      stddev: 3.327131676805893,
+      min: 0,
+      median: 6,
+      max: 12,
+      avg: 4.946428571428571,
+    },
+    {
+      timestamp: '2021-01-13T21:55:18.000000Z',
+      stddev: 0.8293691019953858,
+      min: 10,
+      median: 12,
+      max: 12,
+      avg: 11.416666666666666,
+    },
+    {
+      timestamp: '2021-01-06T21:55:18.000000Z',
+      stddev: 0.4562439130098156,
+      min: 9,
+      median: 10,
+      max: 10,
+      avg: 9.712121212121213,
+    },
+  ],
+})
+
+describe('list witnesses', () => {
+  nock('https://api.helium.io')
+    .get('/v1/hotspots/fake-address/witnesses')
+    .reply(200, {
+      data: [witnessFixture({ name: 'hotspot-1' }), witnessFixture({ name: 'hotspot-2' })],
+    })
+
+  nock('https://api.helium.io')
+    .get(
+      '/v1/hotspots/fake-address/witnesses/sum?min_time=2020-12-17T00%3A00%3A00.000Z&max_time=2020-12-18T00%3A00%3A00.000Z&bucket=week',
+    )
+    .reply(200, witnessSumFixture())
+
+  nock('https://api.helium.io')
+    .get('/v1/hotspots/fake-address/witnesses/sum?min_time=-30%20day&bucket=week')
+    .reply(200, witnessSumFixture())
+
+  it('lists hotspots witnesses', async () => {
+    const client = new Client()
+    const list = await client.hotspot('fake-address').witnesses.list()
+    const witnesses = await list.take(2)
+    expect(witnesses[0].name).toBe('hotspot-1')
+    expect(witnesses[1].name).toBe('hotspot-2')
+    expect(witnesses[0].witnessFor).toBe('fake-witness-for-address')
+    expect(witnesses[0].witnessInfo?.histogram?.['-92']).toBe(21)
+  })
+
+  it('lists hotspot witness sums with date time', async () => {
+    const client = new Client()
+    const list = await client
+      .hotspot('fake-address')
+      .witnesses.sum.list({ minTime: '-30 day', bucket: 'week' })
+    const witnessSums = await list.take(4)
+    expect(witnessSums.length).toBe(4)
+    expect(witnessSums[0].max).toBe(9)
+  })
+
+  it('lists hotspot witness sums with string time', async () => {
+    const client = new Client()
+    const minTime = new Date('2020-12-17T00:00:00Z')
+    const maxTime = new Date('2020-12-18T00:00:00Z')
+    const list = await client
+      .hotspot('fake-address')
+      .witnesses.sum.list({ minTime, maxTime, bucket: 'week' })
+    const witnessSums = await list.take(4)
+    expect(witnessSums.length).toBe(4)
+    expect(witnessSums[0].max).toBe(9)
+  })
+})

--- a/packages/http/src/resources/__tests__/Witnesses.spec.ts
+++ b/packages/http/src/resources/__tests__/Witnesses.spec.ts
@@ -28,7 +28,7 @@ export const witnessFixture = (params = {}) => ({
   gain: 12,
   elevation: 3,
   witness_info: {
-    recent_time: 1618969231803488000,
+    recent_time: '1618969231803488000',
     histogram: {
       '28': 0,
       '-92': 21,
@@ -42,7 +42,7 @@ export const witnessFixture = (params = {}) => ({
       '-108': 0,
       '-100': 1,
     },
-    first_time: 1618163719840575700,
+    first_time: '1618163719840575700',
   },
   witness_for: 'fake-witness-for-address',
   ...params,
@@ -115,6 +115,8 @@ describe('list witnesses', () => {
     expect(witnesses[1].name).toBe('hotspot-2')
     expect(witnesses[0].witnessFor).toBe('fake-witness-for-address')
     expect(witnesses[0].witnessInfo?.histogram?.['-92']).toBe(21)
+    expect(witnesses[0].witnessInfo?.recentTime).toBe('1618969231803488000')
+    expect(witnesses[0].witnessInfo?.firstTime).toBe('1618163719840575700')
   })
 
   it('lists hotspot witness sums with date time', async () => {


### PR DESCRIPTION
I was hoping to just have the `Witness` model extend the `Hotspot` model, but ran into some issues with dependency cycles. So just duplicated the `Hotspot` model and added the witness-specific fields