### PR TITLE
payment v2 memos

### DIFF
--- a/integration_tests/yarn.lock
+++ b/integration_tests/yarn.lock
@@ -2,47 +2,29 @@
 # yarn lockfile v1
 
 
-"@helium/crypto@^3.7.0":
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/@helium/crypto/-/crypto-3.7.0.tgz#9645cad30443582a3cf646457419d8480add785a"
-  integrity sha512-pcy/HyIdWlXNaETAN7QJgpIET9HTZ2AL1aVmm/fHVG5dx28FZFDmjIzxSAfhva2MqpLcYfvr6zNlR66V1pti4g==
+"@helium/crypto@^3.24.0":
+  version "3.24.0"
+  resolved "https://registry.yarnpkg.com/@helium/crypto/-/crypto-3.24.0.tgz#5aa88945a0c646ae5f38e5bd8560a5fd18ee2157"
+  integrity sha512-XUk2oJOEPYx5LN+NyNw1Y/jhIum+NaZEeZLjvqNAtgEqgVlEkPKcZNc1vJwb7r1qftY92O6P0owRTC2vhexmUg==
   dependencies:
     bs58 "^4.0.1"
     create-hash "^1.2.0"
     libsodium-wrappers "^0.7.6"
 
-"@helium/currency@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@helium/currency/-/currency-3.0.0.tgz#c730be8fded993f311f40e6c02f4ac100b4d30d9"
-  integrity sha512-Nh83a+N+kQ12Je2lbr4knJ878+cVHKLq82wNvQVmnJu+3E35Lzo7a0zzRf84iLI1dW+dLsWWCclujA1JvY8yIA==
-  dependencies:
-    bignumber.js "^9.0.0"
-
-"@helium/http@^3.13.1":
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/@helium/http/-/http-3.13.1.tgz#fed621d32d068c0c133a1882bf4a2268c508f4df"
-  integrity sha512-JhrsQkduCw/jnGa9H471tCFB1rXHUYX+EwJQxGgNqHiVGX86oGzrlZ9thraNKItFt+2RVV2bicM4cpUFWWKh7g==
-  dependencies:
-    "@helium/currency" "^3.0.0"
-    axios "^0.21.0"
-    camelcase-keys "^6.2.2"
-    qs "^6.9.3"
-    retry-axios "^2.1.2"
-
-"@helium/proto@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@helium/proto/-/proto-1.2.0.tgz#58ec69569bdb53e3377ea7e59acbd426a0d28f14"
-  integrity sha512-Dcqvf/4l1yIIu/43vxUw6fujrRlP+9kqkRzbQ/CUWyPlhYw96v/QU19b6KX7kwEAF4h9lO08yHqqIohNejeatg==
+"@helium/proto@^1.3.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@helium/proto/-/proto-1.4.0.tgz#7a0ce268642173966519c2fb5f6e57508bff76d1"
+  integrity sha512-0yzzwfwpygowZNqB/9+vI/0gq5TV55ALAUqVuX6TbZZd9DGv4+AHICLiaIandLBBmNPpFzJ0c/IBdBcHJS/g1w==
   dependencies:
     protobufjs "^6.8.9"
 
-"@helium/transactions@^3.11.0":
-  version "3.11.0"
-  resolved "https://registry.yarnpkg.com/@helium/transactions/-/transactions-3.11.0.tgz#8deb5b2a967e1720472ba7d343299c8d3c0525df"
-  integrity sha512-dvENPY+DTGBgd/UKnVbPMm1XBMJqEVpH3v7Pa2aG/MvXjbZljB0IGjL8emTnuK74SkYSbmeCFjNNPlxX8m4thA==
+"@helium/transactions@^3.30.0":
+  version "3.30.0"
+  resolved "https://registry.yarnpkg.com/@helium/transactions/-/transactions-3.30.0.tgz#b0bdc20f08f6573271a05f37542c070ea0cefc54"
+  integrity sha512-LuZI7ybo4czDDXYEIqDreAdCH954Nj9MxIPDJxRAsChmWX7v76JTyAJUk5PYNgXePXL7Grl9+xRc4l+9jvKGqQ==
   dependencies:
-    "@helium/crypto" "^3.7.0"
-    "@helium/proto" "^1.2.0"
+    "@helium/crypto" "^3.24.0"
+    "@helium/proto" "^1.3.0"
     "@types/libsodium-wrappers" "^0.7.8"
     long "^4.0.0"
     path "^0.12.7"
@@ -115,13 +97,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.39.tgz#237d071fb593d3aaa96f655a8eb2f91e0fb1480c"
   integrity sha512-wct+WgRTTkBm2R3vbrFOqyZM5w0g+D8KnhstG9463CJBVC3UVZHMToge7iMBR1vDl/I+NWFHUeK9X+JcF0rWKw==
 
-axios@^0.21.0:
-  version "0.21.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
-  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
-  dependencies:
-    follow-redirects "^1.10.0"
-
 base-x@^3.0.2:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.8.tgz#1e1106c2537f0162e8b52474a557ebb09000018d"
@@ -129,31 +104,12 @@ base-x@^3.0.2:
   dependencies:
     safe-buffer "^5.0.1"
 
-bignumber.js@^9.0.0:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.1.tgz#8d7ba124c882bfd8e43260c67475518d0689e4e5"
-  integrity sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==
-
 bs58@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/bs58/-/bs58-4.0.1.tgz#be161e76c354f6f788ae4071f63f34e8c4f0a42a"
   integrity sha1-vhYedsNU9veIrkBx9j806MTwpCo=
   dependencies:
     base-x "^3.0.2"
-
-camelcase-keys@^6.2.2:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-6.2.2.tgz#5e755d6ba51aa223ec7d3d52f25778210f9dc3c0"
-  integrity sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==
-  dependencies:
-    camelcase "^5.3.1"
-    map-obj "^4.0.0"
-    quick-lru "^4.0.1"
-
-camelcase@^5.3.1:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
-  integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 cipher-base@^1.0.1:
   version "1.0.4"
@@ -173,11 +129,6 @@ create-hash@^1.2.0:
     md5.js "^1.3.4"
     ripemd160 "^2.0.1"
     sha.js "^2.4.0"
-
-follow-redirects@^1.10.0:
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.1.tgz#5f69b813376cee4fd0474a3aba835df04ab763b7"
-  integrity sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==
 
 hash-base@^3.0.0:
   version "3.1.0"
@@ -214,11 +165,6 @@ long@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
   integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
-
-map-obj@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-4.1.0.tgz#b91221b542734b9f14256c0132c897c5d7256fd5"
-  integrity sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -261,16 +207,6 @@ protobufjs@^6.8.9:
     "@types/node" "^13.7.0"
     long "^4.0.0"
 
-qs@^6.9.3:
-  version "6.9.4"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.4.tgz#9090b290d1f91728d3c22e54843ca44aea5ab687"
-  integrity sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==
-
-quick-lru@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
-  integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
-
 readable-stream@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
@@ -279,11 +215,6 @@ readable-stream@^3.6.0:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
-
-retry-axios@^2.1.2:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/retry-axios/-/retry-axios-2.4.0.tgz#b5da2afed8dd0134c73c86206e1d1881d7c66a67"
-  integrity sha512-rK7UBYgbrNoVothbSmM0tEm9DIiXapmVUrnUYn+d9AuQvF0AY5RkJU2FQvlufe9hlFwrCdDhrJTwiyRtR7wUaA==
 
 ripemd160@^2.0.1:
   version "2.0.2"

--- a/packages/http/src/models/Transaction.ts
+++ b/packages/http/src/models/Transaction.ts
@@ -250,6 +250,7 @@ export class UnknownTransaction extends DataModel {
 export interface Payment {
   payee: string
   amount: Balance<NetworkTokens>
+  memo?: string
 }
 
 export class RewardsV1 extends DataModel {

--- a/packages/http/src/models/__tests__/Transaction.spec.ts
+++ b/packages/http/src/models/__tests__/Transaction.spec.ts
@@ -31,7 +31,7 @@ describe('PaymentV2', () => {
     expect(txn.totalAmount.integerBalance).toBe(75)
     expect(txn.fee.integerBalance).toBe(3)
     expect(txn.payments[0].payee).toBe('13DKymsEaCSpNTithKUbyn7zDEYV3xfoAsA2iFM6bsw8YtPaoCZ')
-    expect(txn.payments[0].amount).toBe(75)
+    expect(txn.payments[0].amount.integerBalance).toBe(75)
     expect(txn.payments[0].memo).toBe('memo')
   })
 })

--- a/packages/http/src/models/__tests__/Transaction.spec.ts
+++ b/packages/http/src/models/__tests__/Transaction.spec.ts
@@ -18,6 +18,7 @@ describe('PaymentV2', () => {
         {
           payee: '13DKymsEaCSpNTithKUbyn7zDEYV3xfoAsA2iFM6bsw8YtPaoCZ',
           amount: 75,
+          memo: 'memo',
         },
       ],
       payer: '13sSQT9ZAvcDm7U6GizvUWZbHyT24NpNUdkeq8io7XJ9sggf4Yu',
@@ -29,6 +30,9 @@ describe('PaymentV2', () => {
     const txn = Transaction.fromJsonObject(json) as PaymentV2
     expect(txn.totalAmount.integerBalance).toBe(75)
     expect(txn.fee.integerBalance).toBe(3)
+    expect(txn.payments[0].payee).toBe('13DKymsEaCSpNTithKUbyn7zDEYV3xfoAsA2iFM6bsw8YtPaoCZ')
+    expect(txn.payments[0].amount).toBe(75)
+    expect(txn.payments[0].memo).toBe('memo')
   })
 })
 

--- a/packages/http/src/models/__tests__/Transaction.spec.ts
+++ b/packages/http/src/models/__tests__/Transaction.spec.ts
@@ -30,6 +30,7 @@ describe('PaymentV2', () => {
     const txn = Transaction.fromJsonObject(json) as PaymentV2
     expect(txn.totalAmount.integerBalance).toBe(75)
     expect(txn.fee.integerBalance).toBe(3)
+    expect(txn.data.hash).toBe(txn.hash)
     expect(txn.payments[0].payee).toBe('13DKymsEaCSpNTithKUbyn7zDEYV3xfoAsA2iFM6bsw8YtPaoCZ')
     expect(txn.payments[0].amount.integerBalance).toBe(75)
     expect(txn.payments[0].memo).toBe('memo')
@@ -62,6 +63,7 @@ describe('RewardsV1', () => {
     }
     const txn = Transaction.fromJsonObject(json) as RewardsV1
     expect(txn.totalAmount.integerBalance).toBe(3000)
+    expect(txn.data.hash).toBe(txn.hash)
   })
 })
 
@@ -91,6 +93,7 @@ describe('RewardsV2', () => {
     }
     const txn = Transaction.fromJsonObject(json) as RewardsV2
     expect(txn.totalAmount.integerBalance).toBe(3000)
+    expect(txn.data.hash).toBe(txn.hash)
   })
 })
 
@@ -111,6 +114,7 @@ describe('TransferHotspotV1', () => {
     const txn = Transaction.fromJsonObject(json) as TransferHotspotV1
     expect(txn.amountToSeller.integerBalance).toBe(500000000)
     expect(txn.fee.integerBalance).toBe(55000)
+    expect(txn.data.hash).toBe(txn.hash)
   })
 })
 
@@ -127,5 +131,6 @@ describe('PocReceiptsV1', () => {
       ] as HTTPPathObject[]),
     ) as PocReceiptsV1
     expect(txn.challenger).toBe('fake-challenger')
+    expect(txn.data.hash).toBe(txn.hash)
   })
 })

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@helium/crypto": "^3.24.0",
-    "@helium/proto": "^1.3.0",
+    "@helium/proto": "^1.4.0",
     "@types/libsodium-wrappers": "^0.7.8",
     "long": "^4.0.0",
     "path": "^0.12.7"

--- a/packages/transactions/src/PaymentV2.ts
+++ b/packages/transactions/src/PaymentV2.ts
@@ -96,7 +96,7 @@ export default class PaymentV2 extends Transaction {
     const PaymentTxn = proto.helium.blockchain_txn_payment_v2
     const Payment = proto.helium.payment
     const payments = this.payments.map(({ payee, amount, memo }) => {
-      const memoBuffer = memo ? Buffer.from(memo, 'utf8') : undefined
+      const memoBuffer = memo ? Buffer.from(memo, 'base64') : undefined
       return Payment.create({
         payee: toUint8Array(payee.bin),
         amount,

--- a/packages/transactions/src/PaymentV2.ts
+++ b/packages/transactions/src/PaymentV2.ts
@@ -1,7 +1,10 @@
 import proto from '@helium/proto'
+import * as JSLong from 'long'
 import Transaction from './Transaction'
-import { toUint8Array, EMPTY_SIGNATURE, toAddressable, toNumber } from './utils'
-import { Addressable, SignableKeypair } from './types'
+import {
+  toUint8Array, EMPTY_SIGNATURE, toAddressable, toNumber, toString,
+} from './utils'
+import { Addressable, Base64Memo, SignableKeypair } from './types'
 
 interface PaymentOptions {
   payer?: Addressable
@@ -14,6 +17,7 @@ interface PaymentOptions {
 interface Payment {
   payee: Addressable
   amount: number
+  memo?: Base64Memo
 }
 
 interface SignOptions {
@@ -62,6 +66,7 @@ export default class PaymentV2 extends Transaction {
     const payments = (decoded.paymentV2?.payments || []).map((p) => ({
       payee: toAddressable(p!.payee) as Addressable,
       amount: toNumber(p!.amount) as number,
+      memo: toString(p!.memo),
     }))
     const fee = toNumber(decoded.paymentV2?.fee)
     const nonce = toNumber(decoded.paymentV2?.nonce)
@@ -90,13 +95,14 @@ export default class PaymentV2 extends Transaction {
   ): proto.helium.blockchain_txn_payment_v2 {
     const PaymentTxn = proto.helium.blockchain_txn_payment_v2
     const Payment = proto.helium.payment
-
-    const payments = this.payments.map(({ payee, amount }) =>
-      Payment.create({
+    const payments = this.payments.map(({ payee, amount, memo }) => {
+      const memoBuffer = memo ? Buffer.from(memo, 'utf8') : undefined
+      return Payment.create({
         payee: toUint8Array(payee.bin),
         amount,
-      }),
-    )
+        memo: memoBuffer ? JSLong.fromBytes(Array.from(memoBuffer), true, true) : undefined,
+      })
+    })
 
     return PaymentTxn.create({
       payer: this.payer ? toUint8Array(this.payer.bin) : null,

--- a/packages/transactions/src/TokenBurnV1.ts
+++ b/packages/transactions/src/TokenBurnV1.ts
@@ -2,9 +2,7 @@ import proto from '@helium/proto'
 import * as JSLong from 'long'
 import Transaction from './Transaction'
 import { EMPTY_SIGNATURE, toUint8Array } from './utils'
-import { Addressable, SignableKeypair } from './types'
-
-type Base64Memo = string
+import { Addressable, Base64Memo, SignableKeypair } from './types'
 
 interface TokenBurnOptions {
   payer: Addressable

--- a/packages/transactions/src/__tests__/PaymentV2.spec.ts
+++ b/packages/transactions/src/__tests__/PaymentV2.spec.ts
@@ -22,7 +22,7 @@ const paymentFixture = async () => {
       {
         payee: alice.address,
         amount: 10,
-        memo: 'mockmemo',
+        memo: 'bW9ja21lbW8=',
       },
     ],
     nonce: 1,
@@ -36,7 +36,7 @@ test('create a PaymentV2', async () => {
   expect(payment.payments?.length).toBe(1)
   expect((payment.payments || [])[0].payee.b58).toBe(aliceB58)
   expect((payment.payments || [])[0].amount).toBe(10)
-  expect((payment.payments || [])[0].memo).toBe('mockmemo')
+  expect((payment.payments || [])[0].memo).toBe('bW9ja21lbW8=')
   expect(payment.nonce).toBe(1)
   expect(payment.fee).toBe(35000)
   expect(payment.type).toBe('payment_v2')

--- a/packages/transactions/src/__tests__/PaymentV2.spec.ts
+++ b/packages/transactions/src/__tests__/PaymentV2.spec.ts
@@ -22,6 +22,7 @@ const paymentFixture = async () => {
       {
         payee: alice.address,
         amount: 10,
+        memo: 'mockmemo',
       },
     ],
     nonce: 1,
@@ -35,6 +36,7 @@ test('create a PaymentV2', async () => {
   expect(payment.payments?.length).toBe(1)
   expect((payment.payments || [])[0].payee.b58).toBe(aliceB58)
   expect((payment.payments || [])[0].amount).toBe(10)
+  expect((payment.payments || [])[0].memo).toBe('mockmemo')
   expect(payment.nonce).toBe(1)
   expect(payment.fee).toBe(35000)
   expect(payment.type).toBe('payment_v2')
@@ -65,6 +67,7 @@ describe('serialize and deserialize', () => {
     expect(deserialized.payments[0]?.payee.b58).toBe(
       payment.payments[0]?.payee.b58,
     )
+    expect(deserialized.payments[0]?.memo).toBe(payment.payments[0]?.memo)
     expect(deserialized.fee).toBe(payment.fee)
   })
 })

--- a/packages/transactions/src/__tests__/utils.spec.ts
+++ b/packages/transactions/src/__tests__/utils.spec.ts
@@ -1,5 +1,5 @@
-import {toAddressable, toNumber, toString} from '../utils'
-import * as JSLong from "long";
+import * as JSLong from 'long'
+import { toAddressable, toNumber, toString } from '../utils'
 
 test('toAddressable with undefined', () => {
   expect(toAddressable(undefined)).toBe(undefined)

--- a/packages/transactions/src/__tests__/utils.spec.ts
+++ b/packages/transactions/src/__tests__/utils.spec.ts
@@ -1,4 +1,5 @@
-import { toAddressable, toNumber } from '../utils'
+import {toAddressable, toNumber, toString} from '../utils'
+import * as JSLong from "long";
 
 test('toAddressable with undefined', () => {
   expect(toAddressable(undefined)).toBe(undefined)
@@ -10,4 +11,29 @@ test('toNumber with undefined', () => {
 
 test('toNumber with number', () => {
   expect(toNumber(3)).toBe(3)
+})
+
+describe('toString', () => {
+  test('from long', () => {
+    const base64String = 'bW9ja21lbW8=' // "mockmemo" it can only be 8 bytes max
+    const buff = Buffer.from(base64String, 'base64')
+    const long = JSLong.fromBytes(Array.from(buff), true, true)
+    const result = toString(long) || ''
+    const resultBuff = Buffer.from(result, 'base64')
+    expect(result).toBe(base64String)
+    expect(resultBuff.toString('utf8')).toBe('mockmemo')
+  })
+
+  test('from number', () => {
+    const base64String = 'YWJj' // using js number limits size, string is "abc"
+    const buff = Buffer.from(base64String, 'base64')
+    const long = JSLong.fromBytes(Array.from(buff), true, true)
+    const result = toString(long.toNumber()) || ''
+    const resultBuff = Buffer.from(result, 'base64')
+    expect(resultBuff.toString('utf8')).toMatch('abc')
+  })
+
+  test('undefined', () => {
+    expect(toString(undefined)).toBe(undefined)
+  })
 })

--- a/packages/transactions/src/types.ts
+++ b/packages/transactions/src/types.ts
@@ -7,3 +7,5 @@ export interface Addressable {
 export interface SignableKeypair {
   sign(message: string | Uint8Array): Promise<Uint8Array>
 }
+
+export type Base64Memo = string

--- a/packages/transactions/src/utils.ts
+++ b/packages/transactions/src/utils.ts
@@ -20,7 +20,7 @@ export const toString = (long: Long | number | undefined | null): string | undef
   if (long === undefined || long === null) return undefined
   const jsLong = typeof long === 'number' ? Long.fromNumber(long, true) : long
   const buff = Buffer.from(jsLong.toBytesLE())
-  return buff.toString('utf8')
+  return buff.toString('base64')
 }
 
 export const toNumber = (long: Long | number | undefined | null): number | undefined => {

--- a/packages/transactions/src/utils.ts
+++ b/packages/transactions/src/utils.ts
@@ -16,6 +16,13 @@ export const toAddressable = (
   return Address.fromBin(buf)
 }
 
+export const toString = (long: Long | number | undefined | null): string | undefined => {
+  if (long === undefined || long === null) return undefined
+  const jsLong = typeof long === 'number' ? Long.fromNumber(long, true) : long
+  const buff = Buffer.from(jsLong.toBytesLE())
+  return buff.toString('utf8')
+}
+
 export const toNumber = (long: Long | number | undefined | null): number | undefined => {
   if (long === undefined || long === null) return undefined
   if (typeof long === 'number') return long

--- a/packages/transactions/yarn.lock
+++ b/packages/transactions/yarn.lock
@@ -2,10 +2,19 @@
 # yarn lockfile v1
 
 
-"@helium/proto@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@helium/proto/-/proto-1.3.0.tgz#68657f6c11bdafc9a6cf2920ccd535c5ae244064"
-  integrity sha512-zzkNXDpSeLTrP3U2uBuqkYe2OhlCd8EJi7mowM44XBvba/hx8kHUY53ss3gTJamNpCh8NdbXQtjdCqfg3pQZSg==
+"@helium/crypto@^3.24.0":
+  version "3.24.0"
+  resolved "https://registry.yarnpkg.com/@helium/crypto/-/crypto-3.24.0.tgz#5aa88945a0c646ae5f38e5bd8560a5fd18ee2157"
+  integrity sha512-XUk2oJOEPYx5LN+NyNw1Y/jhIum+NaZEeZLjvqNAtgEqgVlEkPKcZNc1vJwb7r1qftY92O6P0owRTC2vhexmUg==
+  dependencies:
+    bs58 "^4.0.1"
+    create-hash "^1.2.0"
+    libsodium-wrappers "^0.7.6"
+
+"@helium/proto@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@helium/proto/-/proto-1.4.0.tgz#7a0ce268642173966519c2fb5f6e57508bff76d1"
+  integrity sha512-0yzzwfwpygowZNqB/9+vI/0gq5TV55ALAUqVuX6TbZZd9DGv4+AHICLiaIandLBBmNPpFzJ0c/IBdBcHJS/g1w==
   dependencies:
     protobufjs "^6.8.9"
 
@@ -77,15 +86,83 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.19.tgz#1d31ddd5503dba2af7a901aafef3392e4955620e"
   integrity sha512-46/xThm3zvvc9t9/7M3AaLEqtOpqlYYYcCZbpYVAQHG20+oMZBkae/VMrn4BTi6AJ8cpack0mEXhGiKmDNbLrQ==
 
+base-x@^3.0.2:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.8.tgz#1e1106c2537f0162e8b52474a557ebb09000018d"
+  integrity sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==
+  dependencies:
+    safe-buffer "^5.0.1"
+
+bs58@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/bs58/-/bs58-4.0.1.tgz#be161e76c354f6f788ae4071f63f34e8c4f0a42a"
+  integrity sha1-vhYedsNU9veIrkBx9j806MTwpCo=
+  dependencies:
+    base-x "^3.0.2"
+
+cipher-base@^1.0.1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
+  integrity sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==
+  dependencies:
+    inherits "^2.0.1"
+    safe-buffer "^5.0.1"
+
+create-hash@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
+  integrity sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==
+  dependencies:
+    cipher-base "^1.0.1"
+    inherits "^2.0.1"
+    md5.js "^1.3.4"
+    ripemd160 "^2.0.1"
+    sha.js "^2.4.0"
+
+hash-base@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/hash-base/-/hash-base-3.1.0.tgz#55c381d9e06e1d2997a883b4a3fddfe7f0d3af33"
+  integrity sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==
+  dependencies:
+    inherits "^2.0.4"
+    readable-stream "^3.6.0"
+    safe-buffer "^5.2.0"
+
 inherits@2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
+inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+libsodium-wrappers@^0.7.6:
+  version "0.7.9"
+  resolved "https://registry.yarnpkg.com/libsodium-wrappers/-/libsodium-wrappers-0.7.9.tgz#4ffc2b69b8f7c7c7c5594a93a4803f80f6d0f346"
+  integrity sha512-9HaAeBGk1nKTRFRHkt7nzxqCvnkWTjn1pdjKgcUnZxj0FyOP4CnhgFhMdrFfgNsukijBGyBLpP2m2uKT1vuWhQ==
+  dependencies:
+    libsodium "^0.7.0"
+
+libsodium@^0.7.0:
+  version "0.7.9"
+  resolved "https://registry.yarnpkg.com/libsodium/-/libsodium-0.7.9.tgz#4bb7bcbf662ddd920d8795c227ae25bbbfa3821b"
+  integrity sha512-gfeADtR4D/CM0oRUviKBViMGXZDgnFdMKMzHsvBdqLBHd9ySi6EtYnmuhHVDDYgYpAO8eU8hEY+F8vIUAPh08A==
+
 long@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
   integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
+
+md5.js@^1.3.4:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
+  integrity sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==
+  dependencies:
+    hash-base "^3.0.0"
+    inherits "^2.0.1"
+    safe-buffer "^5.1.2"
 
 path@^0.12.7:
   version "0.12.7"
@@ -118,6 +195,48 @@ protobufjs@^6.8.9:
     "@types/long" "^4.0.0"
     "@types/node" "^10.1.0"
     long "^4.0.0"
+
+readable-stream@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
+  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
+ripemd160@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
+  integrity sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==
+  dependencies:
+    hash-base "^3.0.0"
+    inherits "^2.0.1"
+
+safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
+sha.js@^2.4.0:
+  version "2.4.11"
+  resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
+  integrity sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==
+  dependencies:
+    inherits "^2.0.1"
+    safe-buffer "^5.0.1"
+
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
+
+util-deprecate@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
 util@^0.10.3:
   version "0.10.4"


### PR DESCRIPTION
Adds support for memos in payment v2 transactions.

The memo is passed around in Helium JS and the API as a base64 encoded string, but is represented as a byte long on the blockchain.

The flow will be:
1. User enters up to 8 bytes of text in the payment memo field
2. We encode that text from utf8 to base64 and send it to helium-js. Helium-js encodes the base 64 to a long representation fo the bytes.
3. The API sends us the base64 string and we can decode it back to utf8 to get the plain text.