### PR TITLE
Fix URL path for /hotspots/elected

### DIFF
--- a/packages/http/src/resources/Hotspots.ts
+++ b/packages/http/src/resources/Hotspots.ts
@@ -24,7 +24,7 @@ export default class Hotspots {
     return new Hotspot(this.client, { address })
   }
 
-  async search(term:string): Promise<ResourceList<Hotspot>> {
+  async search(term: string): Promise<ResourceList<Hotspot>> {
     const url = 'hotspots/name'
     const response = await this.client.get(url, { search: term })
     const {
@@ -68,7 +68,7 @@ export default class Hotspots {
   }
 
   async elected(block?: number): Promise<ResourceList<Hotspot>> {
-    const url = block === undefined ? '/elected' : `/elected/${block}`
+    const url = block === undefined ? '/hotspots/elected' : `/hotspots/elected/${block}`
     const response = await this.client.get(url)
     const {
       data: { data: hotspots },


### PR DESCRIPTION
Realized my previous addition of elected hotspots had the wrong API URL, it was pinging:
`https://api.helium.io/v1/elected/858295`
instead of:
`https://api.helium.io/v1/hotspots/elected/858295`