### PR TITLE
fix(transactions): empty memos to undefined

### DIFF
--- a/packages/transactions/src/TokenBurnV1.ts
+++ b/packages/transactions/src/TokenBurnV1.ts
@@ -62,6 +62,7 @@ export default class TokenBurnV1 extends Transaction {
   private toProto(forSigning: boolean = false): proto.helium.blockchain_txn_token_burn_v1 {
     const TokenBurnTxn = proto.helium.blockchain_txn_token_burn_v1
     const memoBuffer = Buffer.from(this.memo, 'base64')
+    const memoLong = JSLong.fromBytes(Array.from(memoBuffer), true, true)
     return TokenBurnTxn.create({
       payer: toUint8Array(this.payer.bin),
       payee: toUint8Array(this.payee.bin),
@@ -69,7 +70,7 @@ export default class TokenBurnV1 extends Transaction {
       nonce: this.nonce,
       signature: this.signature && !forSigning ? toUint8Array(this.signature) : null,
       fee: this.fee,
-      memo: JSLong.fromBytes(Array.from(memoBuffer), true, true),
+      memo: !memoLong.isZero() ? memoLong : undefined,
     })
   }
 

--- a/packages/transactions/src/__tests__/PaymentV2.spec.ts
+++ b/packages/transactions/src/__tests__/PaymentV2.spec.ts
@@ -111,4 +111,15 @@ describe('sign', () => {
     const deserializedPayment = PaymentV2.fromString(serializedPayment)
     expect(deserializedPayment.signature).toEqual(signedPayment.signature)
   })
+
+  it('should sign the correct signature while handling an empty memo', async () => {
+    const payment = await paymentFixture()
+    payment.payments[0].memo = 'AAAAAAAAAAA='
+    const reserializedTxn = PaymentV2.fromString(payment.toString())
+    const { bob } = await usersFixture()
+    const signedPayment = await reserializedTxn.sign({ payer: bob })
+    const decoded = proto.helium.blockchain_txn.decode(Buffer.from(signedPayment.toString(), 'base64'))
+    const base64Signature = (decoded.paymentV2?.signature as Buffer).toString('base64')
+    expect(base64Signature).toEqual('TKUrksvBBTjgjoPEPhFc79+jPzaVN7VBWgKo4+GvDYZ4BO9HujpEuskMSvzVWq0T/tf2KAKd6d+fT3mYnMRYCA==')
+  })
 })

--- a/packages/transactions/src/__tests__/TokenBurnV1.spec.ts
+++ b/packages/transactions/src/__tests__/TokenBurnV1.spec.ts
@@ -69,4 +69,14 @@ describe('sign', () => {
 
     expect(Buffer.byteLength(Buffer.from(signedPayment.signature))).toBe(64)
   })
+
+  it('should sign the correct signature while handling an empty memo', async () => {
+    const tokenBurn = await tokenBurnFixture()
+    tokenBurn.memo = 'AAAAAAAAAAA='
+    const { bob } = await usersFixture()
+    const signedPayment = await tokenBurn.sign({ payer: bob })
+    const decoded = proto.helium.blockchain_txn.decode(Buffer.from(signedPayment.toString(), 'base64'))
+    const base64Signature = (decoded.tokenBurn?.signature as Buffer).toString('base64')
+    expect(base64Signature).toEqual('RQu5O68m7dsfLusCV8/60POwgPxh4/KexWl5DS2OHr3MV/msEo1XJ893RswG/giHFrIuoIQYEaEQ+hSI7LmRBQ==')
+  })
 })

--- a/packages/transactions/src/utils.ts
+++ b/packages/transactions/src/utils.ts
@@ -19,6 +19,7 @@ export const toAddressable = (
 export const toString = (long: Long | number | undefined | null): string | undefined => {
   if (long === undefined || long === null) return undefined
   const jsLong = typeof long === 'number' ? Long.fromNumber(long, true) : long
+  if (jsLong.isZero()) return undefined
   const buff = Buffer.from(jsLong.toBytesLE())
   return buff.toString('base64')
 }


### PR DESCRIPTION
There is an issue for signing `TokenBurnV1` transactions, and signing re-serialized `PaymentV2` transactions. Thankfully, both issue #144 and issue #190 are very informative about these problems. This seems to be due to empty memos, or `'AAAAAAAAAAA='`, where an empty memo is introduced to issue #144 during `fromString()`, and with `TokenBurnV1`'s empty detailed in issue #190. Both are going through `toProto()` with `'AAAAAAAAAAA='` which results in bad signatures due to protobuf's encode handling. This patch should fix both issues by removing empty memos from both instances before the encode function, which allows for the encode to then attach and handle signatures correctly. Resolves #144, resolves #190.