### PR TITLE
feat(crypto): add support for bip39

### DIFF
--- a/integration_tests/fixtures/users.ts
+++ b/integration_tests/fixtures/users.ts
@@ -39,6 +39,8 @@ export const aliceWords = [
 export const bobB58 = '13M8dUbxymE3xtiAXszRkGMmezMhBS8Li7wEsMojLdb4Sdxc4wc'
 export const aliceB58 = '148d8KTRcKA5JKPekBcKFd4KfvprvFRpjGtivhtmRmnZ8MFYnP3'
 
+export const bobBip39Words = bobWords.map(word => word !== 'energy' ? word : 'episode')
+
 export const usersFixture = async () => ({
   bob: await Keypair.fromWords(bobWords),
   alice: await Keypair.fromWords(aliceWords),

--- a/integration_tests/tests/create_and_submit_payment.spec.ts
+++ b/integration_tests/tests/create_and_submit_payment.spec.ts
@@ -2,7 +2,7 @@ import nock from 'nock'
 import { Keypair, Address } from '@helium/crypto'
 import { Client } from '@helium/http'
 import { PaymentV1, PaymentV2 } from '@helium/transactions'
-import { bobWords, aliceB58 } from '../fixtures/users'
+import { bobWords, bobBip39Words, aliceB58 } from '../fixtures/users'
 
 test('create and submit a payment txn', async () => {
 
@@ -72,4 +72,28 @@ test('create and submit a PaymentV2 txn', async () => {
   const pendingTxn = await client.transactions.submit(serializedTxn)
 
   expect(pendingTxn.hash).toBe('txn hash')
+})
+
+test('using the bip39 checksum word should match serialization', async () => {
+
+  const bob = await Keypair.fromWords(bobBip39Words)
+  const aliceAddress = Address.fromB58(aliceB58)
+
+  const paymentTxn = new PaymentV2({
+    payer: bob.address,
+    payments: [
+      {
+        payee: aliceAddress,
+        amount: 10,
+      },
+    ],
+    nonce: 1,
+  })
+
+  const signedPaymentTxn = await paymentTxn.sign({ payer: bob })
+  const serializedTxn = signedPaymentTxn.toString()
+
+  expect(serializedTxn).toBe(
+    'wgGOAQohATUaccIv7+wiMZNq0oJrIX7OOdn3f8bEljmSYpnDhpKVEiUKIQGcZZ1yPMHoEKcuePfer0c2qH8Q74/PyAEAtTMn5+5JpBAKIAEqQK88GjmG9CrESHVdcL//ZfWD+KsBnbKmZqKlx8oD89FUms7OjZNcL5NiQ4o0jREg+ahkjc2jX4SgKBBniM+QoAA='
+  )
 })

--- a/packages/crypto/src/Keypair.ts
+++ b/packages/crypto/src/Keypair.ts
@@ -44,7 +44,7 @@ export default class Keypair {
   static async fromMnemonic(mnenomic: Mnemonic, netType?: NetType): Promise<Keypair> {
     await sodium.ready
     const entropy = mnenomic.toEntropy()
-    const seed = Buffer.concat([entropy, entropy])
+    const seed = entropy.length === 16 ? Buffer.concat([entropy, entropy]) : entropy
 
     return Keypair.fromEntropy(seed, netType)
   }

--- a/packages/crypto/src/Mnemonic.ts
+++ b/packages/crypto/src/Mnemonic.ts
@@ -48,7 +48,7 @@ export default class Mnemonic {
 
     const entropy = Buffer.from(entropyBytes)
     const newChecksum = deriveChecksumBits(entropy)
-    if (newChecksum !== checksumBits) throw new Error('invalid checksum')
+    if (checksumBits !== '0000' && newChecksum !== checksumBits) throw new Error('invalid checksum')
 
     return entropy
   }

--- a/packages/crypto/src/__tests__/Keypair.spec.ts
+++ b/packages/crypto/src/__tests__/Keypair.spec.ts
@@ -1,5 +1,5 @@
 import { Keypair, Mnemonic } from '..'
-import { bobWords, bobB58 } from '../../../../integration_tests/fixtures/users'
+import { bobWords, bobBip39Words, bobB58 } from '../../../../integration_tests/fixtures/users'
 import { TESTNET } from '../NetType'
 import { bs58NetType } from '../utils'
 
@@ -35,6 +35,14 @@ describe('address', () => {
   it('returns an Address derived from the public key', async () => {
     const account = await Keypair.fromWords(bobWords)
     expect(account.address.b58).toBe(bobB58)
+  })
+})
+
+describe('fromWords', () => {
+  it('returns the same keypair using both bip39 and legacy checksum words', async () => {
+    const legacy = await Keypair.fromWords(bobWords)
+    const bip39 = await Keypair.fromWords(bobBip39Words)
+    expect(legacy).toStrictEqual(bip39)
   })
 })
 

--- a/packages/crypto/src/__tests__/Mnemonic.spec.ts
+++ b/packages/crypto/src/__tests__/Mnemonic.spec.ts
@@ -17,6 +17,19 @@ describe('fromEntropy', () => {
     expect(mnemonic.words.length).toBe(12)
   })
 
+  it('creates a new 24-word mnemonic from given entropy', async () => {
+      const entropy = await randomBytes(32)
+      const mnemonic = Mnemonic.fromEntropy(entropy)
+      expect(mnemonic.words.length).toBe(24)
+    })
+
+  it('should generate bip39 checksum word', async () => {
+      // https://github.com/bitcoinjs/bip39/blob/master/test/vectors.json
+      const entropy = Buffer.from('00000000000000000000000000000000', 'hex')
+      const mnemonic = Mnemonic.fromEntropy(entropy)
+      expect(mnemonic.words[11]).toBe('about')
+    })
+
   it('throws an error if entropy is less than 16 bytes', async () => {
     const entropy = await randomBytes(12)
     expect(() => {
@@ -45,4 +58,11 @@ describe('toEntropy', () => {
     const mnemonic = Mnemonic.fromEntropy(entropy)
     expect(mnemonic.toEntropy()).toEqual(entropy)
   })
+
+  it('returns the entropy originally used to derive a 24-word mnemonic', async () => {
+    const entropy = await randomBytes(32)
+    const mnemonic = Mnemonic.fromEntropy(entropy)
+    expect(mnemonic.toEntropy()).toEqual(entropy)
+  })
+
 })

--- a/packages/crypto/src/__tests__/Utils.spec.ts
+++ b/packages/crypto/src/__tests__/Utils.spec.ts
@@ -7,7 +7,7 @@ import { MAINNET } from '../NetType'
 describe('deriveChecksumBits', () => {
   it('should generate a bip39 checksum from entropy', async () => {
     const entropy = '00000000000000000000000000000000'
-    const entropyBuffer = Buffer.from(entropy, 'hex');
+    const entropyBuffer = Buffer.from(entropy, 'hex')
     const derivedChecksumBits = utils.deriveChecksumBits(entropyBuffer)
     expect(derivedChecksumBits).toStrictEqual('0011')
   })

--- a/packages/crypto/src/__tests__/Utils.spec.ts
+++ b/packages/crypto/src/__tests__/Utils.spec.ts
@@ -3,6 +3,16 @@ import { bobB58, usersFixture } from '../../../../integration_tests/fixtures/use
 import * as bs58 from 'bs58'
 import { MAINNET } from '../NetType'
 
+
+describe('deriveChecksumBits', () => {
+  it('should generate a bip39 checksum from entropy', async () => {
+    const entropy = '00000000000000000000000000000000'
+    const entropyBuffer = Buffer.from(entropy, 'hex');
+    const derivedChecksumBits = utils.deriveChecksumBits(entropyBuffer)
+    expect(derivedChecksumBits).toStrictEqual('0011')
+  })
+})
+
 describe('bs58checkEncode', () => {
   it('should encode a publickey payload to b58 address', async () => {
     const { bob } = await usersFixture()
@@ -28,4 +38,3 @@ describe('bs58ToBin', () => {
   	expect(checksumVerifyBytes).toStrictEqual(checksum)
   })
 })
-

--- a/packages/crypto/src/utils.ts
+++ b/packages/crypto/src/utils.ts
@@ -29,7 +29,7 @@ export const binaryToByte = (bin: string) => parseInt(bin, 2)
 export const deriveChecksumBits = (entropyBuffer: Buffer | string) => {
   const ENT = entropyBuffer.length * 8
   const CS = ENT / 32
-  const hash = sha256(entropyBuffer).toString('hex')
+  const hash = sha256(entropyBuffer)
 
   return bytesToBinary([].slice.call(hash)).slice(0, CS)
 }


### PR DESCRIPTION
This moves mnemonics forward to use the standardized bip39 checksum, and also allows for the legacy generated mnemonics. The [`crypto-react-native`](https://github.com/helium/helium-js/tree/master/packages/crypto-react-native) package hasn't changed, so this doesn't address #188, but perhaps can be used as reference for it.