### PR TITLE
Add cities.get('city-id')

### DIFF
--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -209,6 +209,11 @@ const list = await client.cities.list({ query: 'san francisco' })
 const cities = await list.take(10)
 ```
 
+##### Get specific city data
+```js
+const city = await client.cities.get('city-id')
+```
+
 ##### List hotspots in a city
 ```js
 const list = await client.city('city-id').hotspots.list()

--- a/packages/http/src/models/City.ts
+++ b/packages/http/src/models/City.ts
@@ -10,6 +10,8 @@ export interface HTTPCityObject {
   long_country?: string
   long_city?: string
   hotspot_count?: number
+  offline_count?: number
+  online_count?: number
   city_id: string
 }
 
@@ -32,6 +34,10 @@ export default class City extends DataModel {
 
   public hotspotCount?: number
 
+  public onlineCount?: number
+
+  public offlineCount?: number
+
   public cityId: string
 
   constructor(client: Client, data: HTTPCityObject) {
@@ -44,6 +50,8 @@ export default class City extends DataModel {
     this.longCountry = data.long_country
     this.longCity = data.long_city
     this.hotspotCount = data.hotspot_count
+    this.onlineCount = data.online_count
+    this.offlineCount = data.offline_count
     this.cityId = data.city_id
   }
 

--- a/packages/http/src/resources/Cities.ts
+++ b/packages/http/src/resources/Cities.ts
@@ -25,4 +25,12 @@ export default class Cities {
     const data = cities.map((city: HTTPCityObject) => new City(this.client, city))
     return new ResourceList(data, this.list.bind(this), cursor)
   }
+
+  async get(cityid: string): Promise<City> {
+    const url = `/cities/${cityid}`
+    const {
+      data: { data: city },
+    } = await this.client.get(url)
+    return new City(this.client, city)
+  }
 }

--- a/packages/http/src/resources/__tests__/Cities.spec.ts
+++ b/packages/http/src/resources/__tests__/Cities.spec.ts
@@ -9,6 +9,8 @@ const citiesFixture = (params = {}) => ({
   long_country: 'mock long_country',
   long_city: 'mock long_city',
   hotspot_count: 100,
+  online_count: 90,
+  offline_count: 10,
   ...params,
 })
 
@@ -32,6 +34,12 @@ describe('list', () => {
       ],
     })
 
+  nock('https://api.helium.io')
+    .get('/v1/cities/mock-sf-1')
+    .reply(200, {
+      data: citiesFixture({ city_id: 'mock-sf-1' }),
+    })
+
   it('lists cities', async () => {
     const client = new Client()
     const list = await client.cities.list()
@@ -40,6 +48,15 @@ describe('list', () => {
     expect(cities[0].cityId).toBe('mock-1')
     expect(cities[1].cityId).toBe('mock-2')
     expect(cities[2].cityId).toBe('mock-3')
+  })
+
+  it('gets city info for given city id', async () => {
+    const client = new Client()
+    const city = await client.cities.get('mock-sf-1')
+    expect(city.cityId).toBe(100)
+    expect(city.hotspotCount).toBe(100)
+    expect(city.onlineCount).toBe(90)
+    expect(city.offlineCount).toBe(10)
   })
 
   it('searches cities', async () => {

--- a/packages/http/src/resources/__tests__/Cities.spec.ts
+++ b/packages/http/src/resources/__tests__/Cities.spec.ts
@@ -53,7 +53,7 @@ describe('list', () => {
   it('gets city info for given city id', async () => {
     const client = new Client()
     const city = await client.cities.get('mock-sf-1')
-    expect(city.cityId).toBe(100)
+    expect(city.cityId).toBe('mock-sf-1')
     expect(city.hotspotCount).toBe(100)
     expect(city.onlineCount).toBe(90)
     expect(city.offlineCount).toBe(10)


### PR DESCRIPTION
- also add online / offline hotspot counts to cities (which are now all numbers instead of some being strings)

adding functionality described here: https://github.com/helium/blockchain-http/issues/312

this will be needed for: https://github.com/helium/explorer/pull/633