### PR TITLE
[http] add name property to client

### DIFF
--- a/packages/http/src/Client.ts
+++ b/packages/http/src/Client.ts
@@ -44,22 +44,26 @@ interface BlockFromHeightOrHashFn {
 }
 
 interface Options {
-  retry: number
+  name?: string
+  retry?: number
 }
 
 export default class Client {
   public network!: Network
 
+  public name?: string
+
   public retry!: number
 
   private axios!: AxiosInstance
 
-  constructor(network: Network = Network.production, options: Options = { retry: 5 }) {
+  constructor(network: Network = Network.production, options?: Options) {
     this.network = network
     this.axios = axios.create({
       baseURL: this.network.endpoint,
     })
-    this.retry = options.retry
+    this.name = options?.name
+    this.retry = options?.retry === undefined ? 5 : options?.retry
     if (this.retry > 0) {
       this.axios.defaults.raxConfig = {
         instance: this.axios,
@@ -153,10 +157,18 @@ export default class Client {
   async get(path: string, params: Object = {}) {
     const query = qs.stringify(params)
     const url = query.length > 0 ? [path, query].join('?') : path
-    return this.axios.get(url)
+    let opts
+    if (this.name) {
+      opts = { headers: { 'x-client-name': this.name } }
+    }
+    return this.axios.get(url, opts)
   }
 
   async post(path: string, params: Object = {}) {
-    return this.axios.post(path, params)
+    let opts
+    if (this.name) {
+      opts = { headers: { 'x-client-name': this.name } }
+    }
+    return this.axios.post(path, params, opts)
   }
 }

--- a/packages/http/src/__tests__/Client.spec.ts
+++ b/packages/http/src/__tests__/Client.spec.ts
@@ -74,3 +74,31 @@ describe('retry disabled', () => {
     await expect(makeRequest()).rejects.toThrow('Request failed with status code 503')
   })
 })
+
+describe('name', () => {
+  it('is initialized with a client name', () => {
+    const client = new Client(Network.production, { name: 'Test Client' })
+    expect(client.name).toBe('Test Client')
+  })
+
+  it('adds an x-client-name header to GET requests when name is set', async () => {
+    nock('https://api.helium.io').get('/v1/greeting').reply(200, {
+      greeting: 'hello',
+    })
+
+    const client = new Client(Network.production, { name: 'Test Client' })
+    const { request } = await client.get('/greeting')
+    expect(request.headers['x-client-name']).toBe('Test Client')
+  })
+
+  it('adds an x-client-name header to POST requests when name is set', async () => {
+    nock('https://api.helium.io').post('/v1/greeting', { greeting: 'hello' }).reply(200, {
+      response: 'hey there!',
+    })
+
+    const client = new Client(Network.production, { name: 'Test Client' })
+    const params = { greeting: 'hello' }
+    const { request } = await client.post('/greeting', params)
+    expect(request.headers['x-client-name']).toBe('Test Client')
+  })
+})


### PR DESCRIPTION
adds a name property to the client which sets a `x-client-name` header on the request when set. This is an optional param for now. In the future we could make it required and have the client throw an error on initialization if its name isn't set, but that would require a change to the call signature and require more work than necessary right now.