### PR TITLE
[crypto] allow mnemonics to be created with 12 or 24 words

### DIFF
--- a/packages/crypto-react-native/src/Mnemonic.ts
+++ b/packages/crypto-react-native/src/Mnemonic.ts
@@ -7,6 +7,7 @@ import {
 } from './utils'
 import wordlist from './wordlists/english.json'
 
+export type MnemonicLength = 12 | 24
 export default class Mnemonic {
   public words!: Array<string>
 
@@ -14,8 +15,14 @@ export default class Mnemonic {
     this.words = words
   }
 
-  static async create(): Promise<Mnemonic> {
-    const entropy = await randomBytes(16)
+  static async create(length: MnemonicLength = 12): Promise<Mnemonic> {
+    if (![12, 24].includes(length)) {
+      throw new Error(`supported mnemonic lengths: 12, 24. received ${length}`)
+    }
+
+    const entropyBytes = (16 / 12) * length
+
+    const entropy = await randomBytes(entropyBytes)
     return Mnemonic.fromEntropy(entropy)
   }
 

--- a/packages/crypto/src/Mnemonic.ts
+++ b/packages/crypto/src/Mnemonic.ts
@@ -1,14 +1,24 @@
-import {
-  lpad, deriveChecksumBits, binaryToByte, bytesToBinary,
-} from './utils'
+import { lpad, deriveChecksumBits, binaryToByte, bytesToBinary, randomBytes } from './utils'
 import wordlist from './wordlists/english.json'
 
+export type MnemonicLength = 12 | 24
 
 export default class Mnemonic {
   public words!: Array<string>
 
   constructor(words: Array<string>) {
     this.words = words
+  }
+
+  static async create(length: MnemonicLength = 12): Promise<Mnemonic> {
+    if (![12, 24].includes(length)) {
+      throw new Error(`supported mnemonic lengths: 12, 24. received ${length}`)
+    }
+
+    const entropyBytes = (16 / 12) * length
+
+    const entropy = await randomBytes(entropyBytes)
+    return Mnemonic.fromEntropy(entropy)
   }
 
   static fromEntropy(entropy: Buffer): Mnemonic {

--- a/packages/crypto/src/__tests__/Mnemonic.spec.ts
+++ b/packages/crypto/src/__tests__/Mnemonic.spec.ts
@@ -2,11 +2,29 @@ import { Mnemonic } from '..'
 import { randomBytes } from '../utils'
 import { bobWords } from '../../../../integration_tests/fixtures/users'
 
-
 describe('Mnemonic', () => {
   it('is initialized with a list of words', () => {
     const mnemonic = new Mnemonic(bobWords)
     expect(mnemonic.words).toEqual(bobWords)
+  })
+})
+
+describe('create', () => {
+  it('creates a new mnemonic with 12 words by default', async () => {
+    const mnemonic = await Mnemonic.create()
+    expect(mnemonic.words.length).toBe(12)
+  })
+
+  it('can create a new mnemonic with 24 words', async () => {
+    const mnemonic = await Mnemonic.create(24)
+    expect(mnemonic.words.length).toBe(24)
+  })
+
+  it('raises an error if given a value besides 12 or 24', () => {
+    const expectedError = new Error('supported mnemonic lengths: 12, 24. received 36')
+    Mnemonic.create(36).catch((error) => {
+      expect(error).toEqual(expectedError)
+    })
   })
 })
 
@@ -18,17 +36,17 @@ describe('fromEntropy', () => {
   })
 
   it('creates a new 24-word mnemonic from given entropy', async () => {
-      const entropy = await randomBytes(32)
-      const mnemonic = Mnemonic.fromEntropy(entropy)
-      expect(mnemonic.words.length).toBe(24)
-    })
+    const entropy = await randomBytes(32)
+    const mnemonic = Mnemonic.fromEntropy(entropy)
+    expect(mnemonic.words.length).toBe(24)
+  })
 
   it('should generate bip39 checksum word', async () => {
-      // https://github.com/bitcoinjs/bip39/blob/master/test/vectors.json
-      const entropy = Buffer.from('00000000000000000000000000000000', 'hex')
-      const mnemonic = Mnemonic.fromEntropy(entropy)
-      expect(mnemonic.words[11]).toBe('about')
-    })
+    // https://github.com/bitcoinjs/bip39/blob/master/test/vectors.json
+    const entropy = Buffer.from('00000000000000000000000000000000', 'hex')
+    const mnemonic = Mnemonic.fromEntropy(entropy)
+    expect(mnemonic.words[11]).toBe('about')
+  })
 
   it('throws an error if entropy is less than 16 bytes', async () => {
     const entropy = await randomBytes(12)
@@ -64,5 +82,4 @@ describe('toEntropy', () => {
     const mnemonic = Mnemonic.fromEntropy(entropy)
     expect(mnemonic.toEntropy()).toEqual(entropy)
   })
-
 })


### PR DESCRIPTION
expands the `Mnemonic.create` method in `@helium/crypto-react-native` to create either 12 or 24 word mnemonics. also adds this to the `@helium/crypto` package which didn't have it before.