### PR TITLE
Add /roles support

### DIFF
--- a/packages/http/src/models/Account.ts
+++ b/packages/http/src/models/Account.ts
@@ -9,6 +9,7 @@ import {
 } from '@helium/currency'
 import type Client from '../Client'
 import Transactions from '../resources/Transactions'
+import Roles from '../resources/Roles'
 import PendingTransactions from '../resources/PendingTransactions'
 import Hotspots from '../resources/Hotspots'
 import Challenges from '../resources/Challenges'
@@ -118,6 +119,10 @@ export default class Account extends DataModel {
 
   public get activity(): Transactions {
     return new Transactions(this.client, this)
+  }
+
+  public get roles(): Roles {
+    return new Roles(this.client, this)
   }
 
   public get hotspots(): Hotspots {

--- a/packages/http/src/models/Hotspot.ts
+++ b/packages/http/src/models/Hotspot.ts
@@ -5,6 +5,7 @@ import DataModel from './DataModel'
 import Witnesses from '../resources/Witnesses'
 import Rewards from '../resources/Rewards'
 import Challenges from '../resources/Challenges'
+import Roles from '../resources/Roles'
 
 export type HotspotData = Omit<Hotspot, 'client'>
 
@@ -159,6 +160,10 @@ export default class Hotspot extends DataModel {
 
   public get activity(): Transactions {
     return new Transactions(this.client, this)
+  }
+
+  public get roles(): Roles {
+    return new Roles(this.client, this)
   }
 
   public get witnesses(): Witnesses {

--- a/packages/http/src/models/Role.ts
+++ b/packages/http/src/models/Role.ts
@@ -1,0 +1,44 @@
+/* eslint-disable no-param-reassign */
+/* eslint-disable max-classes-per-file */
+import DataModel from './DataModel'
+
+export interface RoleJsonObject {
+  type: string
+  time: number
+  role: string
+  height: number
+  hash: string
+}
+
+export class RoleObject extends DataModel {
+  type!: string
+
+  time!: number
+
+  role!: string
+
+  height!: number
+
+  hash!: string
+
+  constructor(data: Role) {
+    super()
+    Object.assign(this, data)
+  }
+
+  get data(): Role {
+    return this
+  }
+}
+
+export type AnyRole = RoleObject
+
+export default class Role {
+  public static fromJsonObject(json: RoleJsonObject): AnyRole {
+    return this.toRole(json)
+  }
+
+  static toRole(json: RoleJsonObject): RoleObject {
+    return new RoleObject(json)
+  }
+}

--- a/packages/http/src/models/Role.ts
+++ b/packages/http/src/models/Role.ts
@@ -10,7 +10,7 @@ export interface RoleJsonObject {
   hash: string
 }
 
-export class RoleObject extends DataModel {
+export default class Role extends DataModel {
   type!: string
 
   time!: number
@@ -28,17 +28,5 @@ export class RoleObject extends DataModel {
 
   get data(): Role {
     return this
-  }
-}
-
-export type AnyRole = RoleObject
-
-export default class Role {
-  public static fromJsonObject(json: RoleJsonObject): AnyRole {
-    return this.toRole(json)
-  }
-
-  static toRole(json: RoleJsonObject): RoleObject {
-    return new RoleObject(json)
   }
 }

--- a/packages/http/src/models/Validator.ts
+++ b/packages/http/src/models/Validator.ts
@@ -3,6 +3,7 @@ import type Client from '../Client'
 import DataModel from './DataModel'
 import Transactions from '../resources/Transactions'
 import Rewards from '../resources/Rewards'
+import Roles from '../resources/Roles'
 
 export type ValidatorData = Omit<Validator, 'client'>
 
@@ -95,6 +96,10 @@ export default class Validator extends DataModel {
 
   public get activity(): Transactions {
     return new Transactions(this.client, this)
+  }
+
+  public get roles(): Roles {
+    return new Roles(this.client, this)
   }
 
   public get rewards(): Rewards {

--- a/packages/http/src/resources/Roles.ts
+++ b/packages/http/src/resources/Roles.ts
@@ -1,0 +1,63 @@
+import type Client from '../Client'
+import Role, { AnyRole, RoleJsonObject } from '../models/Role'
+import Block from '../models/Block'
+import Account from '../models/Account'
+import ResourceList from '../ResourceList'
+import Hotspot from '../models/Hotspot'
+import Validator from '../models/Validator'
+
+export type NaturalDate = string // in the format "-${number} ${Bucket}" eg "-1 day"
+
+interface ListParams {
+  cursor?: string
+  filterTypes?: Array<string>
+  minTime?: Date | NaturalDate
+  maxTime?: Date | NaturalDate
+  limit?: number
+}
+
+type Context = Block | Account | Hotspot | Validator
+
+export default class Roles {
+  private client!: Client
+
+  private context?: Context
+
+  constructor(client: Client, context?: Context) {
+    this.client = client
+    this.context = context
+  }
+
+  async list(params: ListParams = {}): Promise<ResourceList<AnyRole>> {
+    const {
+      data: { data: roles, cursor },
+    } = await this.client.get(this.activityUrl, {
+      cursor: params.cursor,
+      filter_types: params.filterTypes ? params.filterTypes.join() : undefined,
+      min_time: params.minTime instanceof Date ? params.minTime?.toISOString() : params.minTime,
+      max_time: params.maxTime instanceof Date ? params.maxTime?.toISOString() : params.maxTime,
+      limit: params.limit,
+    })
+    const data = roles.map((d: RoleJsonObject) => Role.fromJsonObject(d))
+    return new ResourceList(data, this.list.bind(this), cursor)
+  }
+
+  private get activityUrl(): string {
+    let url
+
+    if (this.context instanceof Account) {
+      const account = this.context as Account
+      url = `/accounts/${account.address}/roles`
+    } else if (this.context instanceof Hotspot) {
+      const hotspot = this.context as Hotspot
+      url = `/hotspots/${hotspot.address}/roles`
+    } else if (this.context instanceof Validator) {
+      const validator = this.context as Validator
+      url = `/validators/${validator.address}/roles`
+    } else {
+      throw new Error('Must provide a context to list roles from')
+    }
+
+    return url
+  }
+}

--- a/packages/http/src/resources/Roles.ts
+++ b/packages/http/src/resources/Roles.ts
@@ -1,5 +1,5 @@
 import type Client from '../Client'
-import Role, { AnyRole, RoleJsonObject } from '../models/Role'
+import Role, { RoleJsonObject } from '../models/Role'
 import Block from '../models/Block'
 import Account from '../models/Account'
 import ResourceList from '../ResourceList'
@@ -28,7 +28,7 @@ export default class Roles {
     this.context = context
   }
 
-  async list(params: ListParams = {}): Promise<ResourceList<AnyRole>> {
+  async list(params: ListParams = {}): Promise<ResourceList<Role>> {
     const {
       data: { data: roles, cursor },
     } = await this.client.get(this.activityUrl, {
@@ -38,7 +38,7 @@ export default class Roles {
       max_time: params.maxTime instanceof Date ? params.maxTime?.toISOString() : params.maxTime,
       limit: params.limit,
     })
-    const data = roles.map((d: RoleJsonObject) => Role.fromJsonObject(d))
+    const data = roles.map((d: RoleJsonObject) => d)
     return new ResourceList(data, this.list.bind(this), cursor)
   }
 

--- a/packages/http/src/resources/__tests__/Roles.spec.ts
+++ b/packages/http/src/resources/__tests__/Roles.spec.ts
@@ -1,0 +1,161 @@
+import nock from 'nock'
+import Client from '../../Client'
+import { RoleObject } from '../../models/Role'
+
+describe('list from account', () => {
+  nock('https://api.helium.io')
+    .get('/v1/accounts/my-address/roles')
+    .reply(200, {
+      data: [
+        {
+          type: 'payment_v2',
+          time: 1586629801,
+          role: 'payee',
+          height: 12345,
+          hash: 'fake-hash-1',
+        },
+        {
+          type: 'rewards_v2',
+          time: 1586629801,
+          role: 'payee',
+          height: 12345,
+          hash: 'fake-hash-2',
+        },
+      ],
+    })
+
+  it('lists roles of recent activity for an account', async () => {
+    const client = new Client()
+    const list = await client.account('my-address').roles.list()
+    const roles = (await list.take(2)) as RoleObject[]
+    expect(roles[0].hash).toBe('fake-hash-1')
+    expect(roles[1].hash).toBe('fake-hash-2')
+  })
+})
+
+describe('list from hotspot', () => {
+  nock('https://api.helium.io')
+    .get('/v1/hotspots/fake-hotspot-address/roles')
+    .reply(200, {
+      data: [
+        {
+          type: 'rewards_v2',
+          time: 1638804232,
+          role: 'reward_gateway',
+          height: 1127817,
+          hash: 'fake-hash-1',
+        },
+        {
+          type: 'poc_receipts_v1',
+          time: 1638804232,
+          role: 'challenger',
+          height: 1127818,
+          hash: 'fake-hash-2',
+        },
+        {
+          type: 'poc_request_v1',
+          time: 1638804232,
+          role: 'challenger',
+          height: 1127819,
+          hash: 'fake-hash-3',
+        },
+        {
+          type: 'poc_request_v1',
+          time: 1638804232,
+          role: 'challenger',
+          height: 1127820,
+          hash: 'fake-hash-4',
+        },
+        {
+          type: 'poc_receipts_v1',
+          time: 1638804232,
+          role: 'challengee',
+          height: 1127821,
+          hash: 'fake-hash-5',
+        },
+        {
+          type: 'rewards_v2',
+          time: 1638804232,
+          role: 'reward_gateway',
+          height: 1127822,
+          hash: 'fake-hash-6',
+        },
+        {
+          type: 'poc_receipts_v1',
+          time: 1638804232,
+          role: 'challenger',
+          height: 1127823,
+          hash: 'fake-hash-7',
+        },
+      ],
+    })
+
+  it('lists roles of recent activity for a hotspot', async () => {
+    const client = new Client()
+    const list = await client.hotspot('fake-hotspot-address').roles.list()
+    const roles = (await list.take(7)) as RoleObject[]
+    const txn0 = roles[0]
+    const txn1 = roles[1]
+    const txn2 = roles[2]
+    const txn3 = roles[3]
+    const txn4 = roles[4]
+    const txn5 = roles[5]
+    const txn6 = roles[6]
+
+    expect((txn0 as RoleObject).type).toBe('rewards_v2')
+    expect((txn1 as RoleObject).role).toBe('challenger')
+    expect((txn2 as RoleObject).height).toBe(1127819)
+    expect((txn3 as RoleObject).hash).toBe('fake-hash-4')
+    expect((txn4 as RoleObject).role).toBe('challengee')
+    expect((txn5 as RoleObject).role).toBe('reward_gateway')
+    expect((txn6 as RoleObject).type).toBe('poc_receipts_v1')
+  })
+})
+
+describe('list from validator', () => {
+  nock('https://api.helium.io')
+    .get('/v1/validators/fake-validator-address/roles')
+    .reply(200, {
+      data: [
+        {
+          type: 'validator_heartbeat_v1',
+          time: 1638820953,
+          role: 'validator',
+          height: 1128100,
+          hash: 'fake-hash-1',
+        },
+        {
+          type: 'validator_heartbeat_v1',
+          time: 1638814204,
+          role: 'validator',
+          height: 1128105,
+          hash: 'fake-hash-2',
+        },
+        {
+          type: 'validator_heartbeat_v1',
+          time: 1638808868,
+          role: 'validator',
+          height: 1128110,
+          hash: 'fake-hash-3',
+        },
+        {
+          type: 'validator_heartbeat_v1',
+          time: 1638803130,
+          role: 'validator',
+          height: 1128115,
+          hash: 'fake-hash-4',
+        },
+      ],
+    })
+
+  it('lists roles of recent activity for a validator', async () => {
+    const client = new Client()
+    const list = await client.validator('fake-validator-address').roles.list()
+    const [txn0, txn1, txn2, txn3] = (await list.take(4)) as RoleObject[]
+
+    expect((txn0 as RoleObject).time).toBe(1638820953)
+    expect((txn1 as RoleObject).type).toBe('validator_heartbeat_v1')
+    expect((txn2 as RoleObject).hash).toBe('fake-hash-3')
+    expect((txn3 as RoleObject).hash).toBe('fake-hash-4')
+  })
+})


### PR DESCRIPTION
adds ability to get roles of recent activity by using /roles instead of /activity

used like:
- `client.account('address').roles.list()`
- `client.hotspot('address').roles.list()`
- `client.validator('address').roles.list()`