### PR TITLE
Add ability to add actor param to transactions.get

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage
 docs/
 .yalc
 yalc.lock
+.vscode

--- a/packages/http/src/resources/Transactions.ts
+++ b/packages/http/src/resources/Transactions.ts
@@ -8,6 +8,7 @@ import ResourceList from '../ResourceList'
 import Hotspot from '../models/Hotspot'
 import Validator from '../models/Validator'
 import camelcaseKeys from 'camelcase-keys'
+import snakecaseKeys from 'snakecase-keys'
 
 export type NaturalDate = string // in the format "-${number} ${Bucket}" eg "-1 day"
 
@@ -39,11 +40,11 @@ export default class Transactions {
     return new PendingTransaction(data)
   }
 
-  async get(hash: string): Promise<AnyTransaction> {
+  async get(hash: string, params?: { actor?: string }): Promise<AnyTransaction> {
     const url = `/transactions/${hash}`
     const {
       data: { data },
-    } = await this.client.get(url)
+    } = await this.client.get(url, snakecaseKeys(params || {}))
     return Transaction.fromJsonObject(data)
   }
 
@@ -63,7 +64,9 @@ export default class Transactions {
 
   async count(params?: { filterTypes?: Array<string> }) {
     const url = `${this.activityUrl}/count`
-    const { data: { data } } = await this.client.get(url, {
+    const {
+      data: { data },
+    } = await this.client.get(url, {
       filter_types: params?.filterTypes ? params.filterTypes.join() : undefined,
     })
     return camelcaseKeys(data)

--- a/packages/http/src/resources/__tests__/Transactions.spec.ts
+++ b/packages/http/src/resources/__tests__/Transactions.spec.ts
@@ -52,6 +52,44 @@ describe('get', () => {
   })
 })
 
+describe('gets transaction detail with actor param', () => {
+  nock('https://api.helium.io')
+    .get('/v1/transactions/fake-rewards-hash-1')
+    .query({ actor: 'fake-account-addr' })
+    .reply(200, {
+      data: {
+        type: 'rewards_v2',
+        time: 1641846360,
+        start_epoch: 1175114,
+        rewards: [
+          {
+            type: 'poc_witnesses',
+            gateway: 'fake-gateway-2',
+            amount: 2237068,
+            account: 'fake-account-addr',
+          },
+          {
+            type: 'poc_challengees',
+            gateway: 'fake-gateway-1',
+            amount: 2478094,
+            account: 'fake-account-addr',
+          },
+        ],
+        height: 1175146,
+        hash: 'Tw26EeI4cbC1-zbpUoTOdGtAb1T77ja_bnj9KUvWHV0',
+        end_epoch: 1175145,
+      },
+    })
+
+  it('gets a transaction by hash', async () => {
+    const client = new Client()
+    const txn = (await client.transactions.get('fake-rewards-hash-1', {
+      actor: 'fake-account-addr',
+    })) as RewardsV2
+    expect(txn.rewards[0].account).toBe('fake-account-addr')
+  })
+})
+
 describe('list from account', () => {
   nock('https://api.helium.io')
     .get('/v1/accounts/my-address/activity')


### PR DESCRIPTION
Makes it possible to do:

`client.transactions.get('hash', { actor: 'address' })` to pull rewards details within context of one account, instead of the entire rewards transaction