### PR TITLE
remove the stakejoy network

### DIFF
--- a/packages/http/src/Network.ts
+++ b/packages/http/src/Network.ts
@@ -19,11 +19,6 @@ export default class Network {
     version: 1,
   })
 
-  static stakejoy = new Network({
-    baseURL: 'https://helium-api.stakejoy.com',
-    version: 1,
-  })
-
   public baseURL: string
 
   public version: number


### PR DESCRIPTION
The stakejoy network no longer exists and we should always use `https://api.helium.io`. Currently the old stakejoy endpoint will redirect to `https://api.helium.io` so existing users clients will continue to work.

This is a breaking change, if we wanted to keep it compatible we could also keep the stakejoy network around and just update it to point to`https://api.helium.io`, it may be a good idea to let people know it shouldn't be used anymore though.