### PR TITLE
Added reward type to the Reward model

### DIFF
--- a/packages/http/src/models/Reward.ts
+++ b/packages/http/src/models/Reward.ts
@@ -5,6 +5,7 @@ import Client from '../Client'
 export type RewardData = Omit<Reward, 'client'>
 
 export interface HTTPReward {
+  type: string
   account: string
   amount: number
   block: number
@@ -19,6 +20,8 @@ function integerToBalance(integerValue: number): Balance<NetworkTokens> {
 
 export default class Reward extends DataModel {
   private client: Client
+
+  public type: string
 
   public account: string
 
@@ -35,6 +38,7 @@ export default class Reward extends DataModel {
   constructor(client: Client, rewards: HTTPReward) {
     super()
     this.client = client
+    this.type = rewards.type
     this.account = rewards.account
     this.amount = integerToBalance(rewards.amount)
     this.block = rewards.block


### PR DESCRIPTION
I was trying to move from the activity endpoint and use the new rewards endpoint but this was missing the type of the reward. I've noticed that the type of the reward was added in the API but it is not reflected in this library. 

I am working on updating my platform to be compatible with the new changes that the light hotspots will add to validators and I need to know the types of rewards when fetching them through this library.