### PR TITLE
Fix package entry points

### DIFF
--- a/packages/address/package.json
+++ b/packages/address/package.json
@@ -13,7 +13,7 @@
   "homepage": "https://github.com/helium/helium-js",
   "license": "Apache-2.0",
   "main": "build/index.js",
-  "module": "build/index.es.js",
+  "module": "build/index.js",
   "files": [
     "build"
   ],

--- a/packages/crypto-react-native/package.json
+++ b/packages/crypto-react-native/package.json
@@ -14,7 +14,7 @@
   "homepage": "https://github.com/helium/helium-js",
   "license": "Apache-2.0",
   "main": "build/index.js",
-  "module": "build/index.es.js",
+  "module": "build/index.js",
   "files": [
     "build"
   ],

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -13,7 +13,7 @@
   "homepage": "https://github.com/helium/helium-js",
   "license": "Apache-2.0",
   "main": "build/index.js",
-  "module": "build/index.es.js",
+  "module": "build/index.js",
   "files": [
     "build"
   ],

--- a/packages/currency/package.json
+++ b/packages/currency/package.json
@@ -13,7 +13,7 @@
   "homepage": "https://github.com/helium/helium-js",
   "license": "Apache-2.0",
   "main": "build/index.js",
-  "module": "build/index.es.js",
+  "module": "build/index.js",
   "files": [
     "build"
   ],

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -13,7 +13,7 @@
   "homepage": "https://github.com/helium/helium-js",
   "license": "Apache-2.0",
   "main": "build/index.js",
-  "module": "build/index.es.js",
+  "module": "build/index.js",
   "files": [
     "build"
   ],

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -11,7 +11,7 @@
   "homepage": "https://github.com/helium/helium-js",
   "license": "Apache-2.0",
   "main": "build/index.js",
-  "module": "build/index.es.js",
+  "module": "build/index.js",
   "files": [
     "build"
   ],

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -14,7 +14,7 @@
   "homepage": "https://github.com/helium/helium-js",
   "license": "Apache-2.0",
   "main": "build/index.js",
-  "module": "build/index.es.js",
+  "module": "build/index.js",
   "files": [
     "build"
   ],

--- a/packages/wallet-link/package.json
+++ b/packages/wallet-link/package.json
@@ -13,7 +13,7 @@
   "homepage": "https://github.com/helium/helium-js#readme",
   "license": "Apache-2.0",
   "main": "build/index.js",
-  "module": "build/index.es.js",
+  "module": "build/index.js",
   "files": [
     "build"
   ],


### PR DESCRIPTION
Our packages entry point was set to `build/index.es.js` but that file does not exist in the build folder. Setting this to `build/index.js` should fix this.