### PR TITLE
fix token type

### DIFF
--- a/integration_tests/tests/create_and_submit_payment.spec.ts
+++ b/integration_tests/tests/create_and_submit_payment.spec.ts
@@ -58,7 +58,7 @@ test('create and submit a PaymentV2 txn', async () => {
   const signedPaymentTxn = await paymentTxn.sign({ payer: bob })
   const serializedTxn = signedPaymentTxn.toString()
   expect(serializedTxn).toBe(
-    'wgGOAQohATUaccIv7+wiMZNq0oJrIX7OOdn3f8bEljmSYpnDhpKVEiUKIQGcZZ1yPMHoEKcuePfer0c2qH8Q74/PyAEAtTMn5+5JpBAKIAEqQK88GjmG9CrESHVdcL//ZfWD+KsBnbKmZqKlx8oD89FUms7OjZNcL5NiQ4o0jREg+ahkjc2jX4SgKBBniM+QoAA=',
+    'wgGQAQohATUaccIv7+wiMZNq0oJrIX7OOdn3f8bEljmSYpnDhpKVEicKIQGcZZ1yPMHoEKcuePfer0c2qH8Q74/PyAEAtTMn5+5JpBAKKAAgASpAJCR6qHf+krZ4WU5bTyOgbh+tgc7bJZwVjNQigHNj47736g5jgxbIxCjpwwlvQCH5TrqELYJ75tFrOkU/h4qHCw==',
   )
 
   nock('https://api.helium.io')
@@ -94,7 +94,7 @@ test('using the bip39 checksum word should match serialization', async () => {
   const serializedTxn = signedPaymentTxn.toString()
 
   expect(serializedTxn).toBe(
-    'wgGOAQohATUaccIv7+wiMZNq0oJrIX7OOdn3f8bEljmSYpnDhpKVEiUKIQGcZZ1yPMHoEKcuePfer0c2qH8Q74/PyAEAtTMn5+5JpBAKIAEqQK88GjmG9CrESHVdcL//ZfWD+KsBnbKmZqKlx8oD89FUms7OjZNcL5NiQ4o0jREg+ahkjc2jX4SgKBBniM+QoAA=',
+    'wgGQAQohATUaccIv7+wiMZNq0oJrIX7OOdn3f8bEljmSYpnDhpKVEicKIQGcZZ1yPMHoEKcuePfer0c2qH8Q74/PyAEAtTMn5+5JpBAKKAAgASpAJCR6qHf+krZ4WU5bTyOgbh+tgc7bJZwVjNQigHNj47736g5jgxbIxCjpwwlvQCH5TrqELYJ75tFrOkU/h4qHCw==',
   )
 })
 
@@ -131,6 +131,6 @@ test('create and sign multisig payment', async () => {
 
   const serializedTxn = paymentTxn.toString()
   expect(serializedTxn).toBe(
-    'wgHXAQolAgECEiBqqzKbCO7og1KrG7VnpqrgT+wIowchqqdNAdWDQAa5HRIlCiEBnGWdcjzB6BCnLnj33q9HNqh/EO+Pz8gBALUzJ+fuSaQQCiABKoQBATUaccIv7+wiMZNq0oJrIX7OOdn3f8bEljmSYpnDhpKVAZxlnXI8wegQpy54996vRzaofxDvj8/IAQC1Myfn7kmkAEDfDD6a0GpxsreMPBmr+VACsNHtdEpBnCL1RUzTvqS6N7x9dmSEt8SZeqlTFTmzaLoC8zi4OCNf6zcf+Z347fsH',
+    'wgHZAQolAgECEiBqqzKbCO7og1KrG7VnpqrgT+wIowchqqdNAdWDQAa5HRInCiEBnGWdcjzB6BCnLnj33q9HNqh/EO+Pz8gBALUzJ+fuSaQQCigAIAEqhAEBNRpxwi/v7CIxk2rSgmshfs452fd/xsSWOZJimcOGkpUBnGWdcjzB6BCnLnj33q9HNqh/EO+Pz8gBALUzJ+fuSaQAQDZ3LrtMNKjBCAs1ti0LlRRWlmpMrILOa2Uc9DAmfVKHwqePE8ta6ca+dI3W3lUF3xUJagXNsWJAR4AwmtOERQw=',
   )
 })

--- a/packages/currency/package.json
+++ b/packages/currency/package.json
@@ -26,7 +26,6 @@
     "build": "yarn run clean && tsc"
   },
   "dependencies": {
-    "@helium/transactions": "^4.6.2",
     "bignumber.js": "^9.0.0"
   },
   "gitHead": "16442bef09f90dd9a83d4c9e1a347de3e80575e4"

--- a/packages/currency/src/CurrencyType.ts
+++ b/packages/currency/src/CurrencyType.ts
@@ -1,4 +1,3 @@
-import { TokenType } from '@helium/transactions'
 import {
   BaseCurrencyType,
   DataCredits,
@@ -20,16 +19,16 @@ export type AnyCurrencyType =
   | USDollars
 
 export default class CurrencyType {
-  static fromTokenType(type: TokenType): BaseCurrencyType {
-    switch (type) {
+  static fromTicker(ticker?: string): BaseCurrencyType {
+    switch (ticker?.toUpperCase()) {
       default:
-      case TokenType.hnt:
+      case this.default.ticker:
         return this.default
-      case TokenType.hst:
+      case this.security.ticker:
         return this.security
-      case TokenType.mobile:
+      case this.mobile.ticker:
         return this.mobile
-      case TokenType.iot:
+      case this.iot.ticker:
         return this.iot
     }
   }

--- a/packages/currency/src/__tests__/Balance.spec.ts
+++ b/packages/currency/src/__tests__/Balance.spec.ts
@@ -1,4 +1,3 @@
-import { TokenType } from '@helium/transactions'
 import { Balance, CurrencyType } from '..'
 import { UnsupportedCurrencyConversionError } from '../Errors'
 
@@ -256,10 +255,15 @@ describe('trying to convert a security token balance', () => {
 })
 
 describe('CurrencyType', () => {
-  it('fromTokenType', () => {
-    expect(CurrencyType.fromTokenType(TokenType.hnt).ticker).toBe('HNT')
-    expect(CurrencyType.fromTokenType(TokenType.hst).ticker).toBe('HST')
-    expect(CurrencyType.fromTokenType(TokenType.mobile).ticker).toBe('MOBILE')
-    expect(CurrencyType.fromTokenType(TokenType.iot).ticker).toBe('IOT')
+  it('fromTicker', () => {
+    expect(CurrencyType.fromTicker(undefined).ticker).toBe('HNT')
+    expect(CurrencyType.fromTicker('hnt').ticker).toBe('HNT')
+    expect(CurrencyType.fromTicker('HNT').ticker).toBe('HNT')
+    expect(CurrencyType.fromTicker('hst').ticker).toBe('HST')
+    expect(CurrencyType.fromTicker('HST').ticker).toBe('HST')
+    expect(CurrencyType.fromTicker('mobile').ticker).toBe('MOBILE')
+    expect(CurrencyType.fromTicker('MOBILE').ticker).toBe('MOBILE')
+    expect(CurrencyType.fromTicker('iot').ticker).toBe('IOT')
+    expect(CurrencyType.fromTicker('IOT').ticker).toBe('IOT')
   })
 })

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "@helium/address": "^4.6.2",
     "@helium/currency": "^4.6.2",
-    "@helium/transactions": "^4.6.2",
     "axios": "^0.21.1",
     "camelcase-keys": "^6.2.2",
     "qs": "^6.9.3",

--- a/packages/http/src/models/__tests__/Transaction.spec.ts
+++ b/packages/http/src/models/__tests__/Transaction.spec.ts
@@ -1,4 +1,3 @@
-import { TokenType } from '@helium/transactions'
 import Transaction, {
   PaymentV2,
   PocReceiptsV1,
@@ -118,6 +117,7 @@ describe('PaymentV2', () => {
     expect(txn.data.hash).toBe(txn.hash)
     expect(txn.payments[0].payee).toBe('13DKymsEaCSpNTithKUbyn7zDEYV3xfoAsA2iFM6bsw8YtPaoCZ')
     expect(txn.payments[0].amount.integerBalance).toBe(75)
+    expect(txn.payments[0].amount.type.ticker).toBe('HNT')
     expect(txn.payments[0].memo).toBe('memo')
   })
 })
@@ -291,7 +291,7 @@ describe('SubnetworkRewardsV1', () => {
   it('correctly converts mobile token json', () => {
     const json = {
       type: 'subnetwork_rewards_v1',
-      token_type: TokenType.mobile,
+      token_type: 'mobile',
       time: 1587424041,
       start_epoch: 300165,
       rewards: [
@@ -309,7 +309,7 @@ describe('SubnetworkRewardsV1', () => {
       end_epoch: 300195,
     }
     const txn = Transaction.fromJsonObject(json) as SubnetworkRewardsV1
-    expect(txn.tokenType).toBe(TokenType.mobile)
+    expect(txn.tokenType).toBe('mobile')
     expect(txn.rewards.length).toBe(2)
     expect(txn.rewards[0].amount.floatBalance).toBe(0.00002)
     expect(txn.rewards[0].amount.type.ticker).toBe('MOBILE')
@@ -318,7 +318,7 @@ describe('SubnetworkRewardsV1', () => {
   it('correctly converts iot token json', () => {
     const json = {
       type: 'subnetwork_rewards_v1',
-      token_type: TokenType.iot,
+      token_type: 'iot',
       time: 1587424041,
       start_epoch: 300165,
       rewards: [
@@ -336,7 +336,7 @@ describe('SubnetworkRewardsV1', () => {
       end_epoch: 300195,
     }
     const txn = Transaction.fromJsonObject(json) as SubnetworkRewardsV1
-    expect(txn.tokenType).toBe(TokenType.iot)
+    expect(txn.tokenType).toBe('iot')
     expect(txn.rewards.length).toBe(2)
     expect(txn.rewards[0].amount.floatBalance).toBe(0.00002)
     expect(txn.rewards[0].amount.type.ticker).toBe('IOT')
@@ -349,15 +349,15 @@ describe('TokenRedeemV1', () => {
       type: 'token_redeem_v1',
       account: 'fake-owner-address',
       amount: 2000,
-      token_type: TokenType.mobile,
+      token_type: 'mobile',
       nonce: 1,
       time: 1587424041,
       height: 123456,
       hash: 'fake-txn-hash',
     }
     const txn = Transaction.fromJsonObject(json) as TokenRedeemV1
-    expect(txn.amount.type.ticker).toBe('HNT')
-    expect(txn.tokenType).toBe(TokenType.mobile)
+    expect(txn.amount.type.ticker).toBe('MOBILE')
+    expect(txn.tokenType).toBe('mobile')
   })
 
   it('correctly converts hnt to iot txn json', () => {
@@ -365,14 +365,14 @@ describe('TokenRedeemV1', () => {
       type: 'token_redeem_v1',
       account: 'fake-owner-address',
       amount: 2000,
-      token_type: TokenType.iot,
+      token_type: 'iot',
       nonce: 1,
       time: 1587424041,
       height: 123456,
       hash: 'fake-txn-hash',
     }
     const txn = Transaction.fromJsonObject(json) as TokenRedeemV1
-    expect(txn.amount.type.ticker).toBe('HNT')
-    expect(txn.tokenType).toBe(TokenType.iot)
+    expect(txn.amount.type.ticker).toBe('IOT')
+    expect(txn.tokenType).toBe('iot')
   })
 })

--- a/packages/transactions/src/SubnetworkRewardsV1.ts
+++ b/packages/transactions/src/SubnetworkRewardsV1.ts
@@ -1,12 +1,17 @@
 import proto from '@helium/proto'
 import Transaction from './Transaction'
 import {
-  EMPTY_SIGNATURE, toAddressable, toNumber, toUint8Array,
+  EMPTY_SIGNATURE,
+  toAddressable,
+  toNumber,
+  toTicker,
+  toTokenType,
+  toUint8Array,
 } from './utils'
-import { Addressable, SignableKeypair, TokenType } from './types'
+import { Addressable, SignableKeypair } from './types'
 
 interface Options {
-  tokenType: number
+  tokenType: string
   startEpoch: number
   endEpoch: number
   rewards: Array<SubnetworkReward>
@@ -23,7 +28,7 @@ export interface SubnetworkReward {
 }
 
 export default class SubnetworkRewardsV1 extends Transaction {
-  public tokenType?: number
+  public tokenType?: string
 
   public startEpoch?: number
 
@@ -66,7 +71,7 @@ export default class SubnetworkRewardsV1 extends Transaction {
   static fromString(serializedTxnString: string) {
     const buf = Buffer.from(serializedTxnString, 'base64')
     const decoded = proto.helium.blockchain_txn.decode(buf)
-    const tokenType = toNumber(decoded.subnetworkRewards?.tokenType) || TokenType.hnt
+    const tokenType = toTicker(toNumber(decoded.subnetworkRewards?.tokenType))
     const startEpoch = toNumber(decoded.subnetworkRewards?.startEpoch) || 0
     const endEpoch = toNumber(decoded.subnetworkRewards?.endEpoch) || 0
     const rewards = (decoded.subnetworkRewards?.rewards || []).map((p) => ({
@@ -94,7 +99,7 @@ export default class SubnetworkRewardsV1 extends Transaction {
     }))
 
     return SubnetworkRewards.create({
-      tokenType: this.tokenType,
+      tokenType: toTokenType(this.tokenType),
       startEpoch: this.startEpoch,
       endEpoch: this.endEpoch,
       rewards,

--- a/packages/transactions/src/TokenRedeemV1.ts
+++ b/packages/transactions/src/TokenRedeemV1.ts
@@ -1,7 +1,7 @@
 import proto from '@helium/proto'
 import Transaction from './Transaction'
 import {
-  toUint8Array, EMPTY_SIGNATURE, toAddressable, toNumber,
+  toUint8Array, EMPTY_SIGNATURE, toAddressable, toNumber, toTokenType, toTicker,
 } from './utils'
 import { Addressable, SignableKeypair } from './types'
 
@@ -10,7 +10,7 @@ interface Options {
   amount?: number
   fee?: number
   nonce?: number
-  tokenType?: number
+  tokenType?: string
   signature?: Uint8Array
 }
 
@@ -27,7 +27,7 @@ export default class TokenRedeemV1 extends Transaction {
 
   public nonce?: number
 
-  public tokenType?: number
+  public tokenType?: string
 
   public signature?: Uint8Array
 
@@ -76,7 +76,7 @@ export default class TokenRedeemV1 extends Transaction {
       amount: this.amount,
       fee: this.fee && this.fee > 0 ? this.fee : null,
       nonce: this.nonce,
-      tokenType: this.tokenType,
+      tokenType: toTokenType(this.tokenType),
       signature:
         this.signature && !forSigning ? toUint8Array(this.signature) : null,
     })
@@ -88,7 +88,7 @@ export default class TokenRedeemV1 extends Transaction {
 
     const account = toAddressable(tokenRedeem?.account)
     const amount = toNumber(tokenRedeem?.amount) || 0
-    const tokenType = toNumber(tokenRedeem?.tokenType)
+    const tokenType = toTicker(toNumber(tokenRedeem?.tokenType))
     const fee = toNumber(tokenRedeem?.fee)
     const nonce = toNumber(tokenRedeem?.nonce)
     const signature = tokenRedeem?.signature?.length

--- a/packages/transactions/src/__tests__/PaymentV2.spec.ts
+++ b/packages/transactions/src/__tests__/PaymentV2.spec.ts
@@ -1,5 +1,5 @@
 import proto from '@helium/proto'
-import { PaymentV2, TokenType, Transaction } from '..'
+import { PaymentV2, Transaction } from '..'
 import {
   usersFixture,
   bobB58,
@@ -23,7 +23,7 @@ const paymentFixture = async () => {
         payee: alice.address,
         amount: 10,
         memo: 'bW9ja21lbW8=',
-        tokenType: TokenType.hnt,
+        tokenType: 'hnt',
       },
     ],
     nonce: 1,
@@ -38,7 +38,7 @@ test('create a PaymentV2', async () => {
   expect((payment.payments || [])[0].payee.b58).toBe(aliceB58)
   expect((payment.payments || [])[0].amount).toBe(10)
   expect((payment.payments || [])[0].memo).toBe('bW9ja21lbW8=')
-  expect((payment.payments || [])[0].tokenType).toBe(TokenType.hnt)
+  expect((payment.payments || [])[0].tokenType).toBe('hnt')
   expect(payment.nonce).toBe(1)
   expect(payment.fee).toBe(35000)
   expect(payment.type).toBe('payment_v2')
@@ -70,6 +70,7 @@ describe('serialize and deserialize', () => {
       payment.payments[0]?.payee.b58,
     )
     expect(deserialized.payments[0]?.memo).toBe(payment.payments[0]?.memo)
+    expect(deserialized.payments[0]?.tokenType).toBe(payment.payments[0]?.tokenType)
     expect(deserialized.fee).toBe(payment.fee)
   })
 })

--- a/packages/transactions/src/__tests__/SubnetworkRewardsV1.spec.ts
+++ b/packages/transactions/src/__tests__/SubnetworkRewardsV1.spec.ts
@@ -1,6 +1,6 @@
 import proto from '@helium/proto'
 import { utils } from '@helium/crypto'
-import { TokenType, Transaction, SubnetworkRewardsV1 } from '..'
+import { Transaction, SubnetworkRewardsV1 } from '..'
 import { usersFixture, bobB58, aliceB58 } from '../../../../integration_tests/fixtures/users'
 
 Transaction.config({
@@ -14,7 +14,7 @@ const fixture = async () => {
   const { bob, alice } = await usersFixture()
 
   return new SubnetworkRewardsV1({
-    tokenType: TokenType.mobile,
+    tokenType: 'mobile',
     startEpoch: 1000,
     endEpoch: 2000,
     rewards: [
@@ -26,7 +26,7 @@ const fixture = async () => {
 
 test('create a subnetwork rewards txn', async () => {
   const txn = await fixture()
-  expect(txn.tokenType).toBe(TokenType.mobile)
+  expect(txn.tokenType).toBe('mobile')
   expect(txn.startEpoch).toBe(1000)
   expect(txn.endEpoch).toBe(2000)
   expect(txn.rewards.length).toBe(2)
@@ -49,7 +49,24 @@ describe('serialize', () => {
     // verify that we can decode it back from its serialized string
     const buf = Buffer.from(txnString, 'base64')
     const decoded = proto.helium.blockchain_txn.decode(buf)
-    expect(decoded.subnetworkRewards?.tokenType).toBe(TokenType.mobile)
+    expect(decoded.subnetworkRewards?.startEpoch?.toString()).toBe('1000')
+  })
+})
+
+describe('fromString', () => {
+  it('deserializes a txn from string', async () => {
+    const txn = await fixture()
+    const txnString = txn.toString()
+    const decoded = SubnetworkRewardsV1.fromString(txnString)
+    expect(decoded.tokenType).toBe('mobile')
+    expect(decoded.startEpoch).toBe(1000)
+    expect(decoded.endEpoch).toBe(2000)
+    expect(decoded.rewards.length).toBe(2)
+    expect(decoded.rewards[0].account.b58).toBe(bobB58)
+    expect(decoded.rewards[0].amount).toBe(1000)
+    expect(decoded.rewards[1].account.b58).toBe(aliceB58)
+    expect(decoded.rewards[1].amount).toBe(2000)
+    expect(decoded.type).toBe('subnetwork_rewards_v1')
   })
 })
 

--- a/packages/transactions/src/__tests__/TokenRedeemV1.spec.ts
+++ b/packages/transactions/src/__tests__/TokenRedeemV1.spec.ts
@@ -1,6 +1,6 @@
 import proto from '@helium/proto'
 import { utils } from '@helium/crypto'
-import { Transaction, TokenRedeemV1, TokenType } from '..'
+import { Transaction, TokenRedeemV1 } from '..'
 import { usersFixture, bobB58 } from '../../../../integration_tests/fixtures/users'
 
 Transaction.config({
@@ -14,7 +14,7 @@ const fixture = async () => {
   const { bob } = await usersFixture()
 
   return new TokenRedeemV1({
-    tokenType: TokenType.mobile,
+    tokenType: 'mobile',
     account: bob.address,
     amount: 10,
     nonce: 1,
@@ -28,6 +28,7 @@ test('create a token convert txn', async () => {
   expect(txn.nonce).toBe(1)
   expect(txn.fee).toBe(25000)
   expect(txn.type).toBe('token_redeem_v1')
+  expect(txn.tokenType).toBe('mobile')
 })
 
 describe('serialize', () => {
@@ -43,6 +44,20 @@ describe('serialize', () => {
     const buf = Buffer.from(txnString, 'base64')
     const decoded = proto.helium.blockchain_txn.decode(buf)
     expect(decoded.tokenRedeem?.amount?.toString()).toBe('10')
+  })
+})
+
+describe('fromString', () => {
+  it('deserializes a txn from string', async () => {
+    const txn = await fixture()
+    const txnString = txn.toString()
+    const decoded = TokenRedeemV1.fromString(txnString)
+    expect(decoded.account?.b58).toBe(bobB58)
+    expect(decoded.amount).toBe(10)
+    expect(decoded.nonce).toBe(1)
+    expect(decoded.fee).toBe(25000)
+    expect(decoded.type).toBe('token_redeem_v1')
+    expect(decoded.tokenType).toBe('mobile')
   })
 })
 
@@ -83,7 +98,7 @@ describe('fees', () => {
     const { bob } = await usersFixture()
 
     const txn = new TokenRedeemV1({
-      tokenType: TokenType.mobile,
+      tokenType: 'mobile',
       account: bob.address,
       amount: 10,
       nonce: 1,

--- a/packages/transactions/src/utils.ts
+++ b/packages/transactions/src/utils.ts
@@ -1,6 +1,6 @@
 import Address from '@helium/address'
 import Long from 'long'
-import { Addressable } from './types'
+import { Addressable, TokenType } from './types'
 
 export const toUint8Array = (
   str: string | Uint8Array | undefined | null,
@@ -28,4 +28,32 @@ export const toNumber = (long: Long | number | undefined | null): number | undef
   if (long === undefined || long === null) return undefined
   if (typeof long === 'number') return long
   return long.toNumber()
+}
+
+export const toTokenType = (ticker?: string): number => {
+  switch (ticker?.toLowerCase()) {
+    default:
+    case 'hnt':
+      return TokenType.hnt
+    case 'hst':
+      return TokenType.hst
+    case 'mobile':
+      return TokenType.mobile
+    case 'iot':
+      return TokenType.iot
+  }
+}
+
+export const toTicker = (tokenType?: number): string => {
+  switch (tokenType) {
+    default:
+    case TokenType.hnt:
+      return 'hnt'
+    case TokenType.hst:
+      return 'hst'
+    case TokenType.mobile:
+      return 'mobile'
+    case TokenType.iot:
+      return 'iot'
+  }
 }


### PR DESCRIPTION
token type comes from the API as a lowercase ticker. We will preserve that interface up until transaction serialization at which point it gets converted to an integer, following the protobuf enum. This also removes the dependency on `@helium/transactions` from `@helium/currency` and `@helium/http`