### PR TITLE
Add default formatting options to balance

### DIFF
--- a/packages/currency/src/Balance.ts
+++ b/packages/currency/src/Balance.ts
@@ -40,13 +40,6 @@ type StringFormatOptions = {
 
 const DC_TO_USD_MULTIPLIER = 0.00001
 
-const getVal = <T>(localValue?: T, defaultValue?: T) => {
-  if (localValue !== undefined) {
-    return localValue
-  }
-  return defaultValue
-}
-
 export default class Balance<T extends BaseCurrencyType> {
   public type: T
 
@@ -78,11 +71,8 @@ export default class Balance<T extends BaseCurrencyType> {
     const showTicker = options?.showTicker === undefined ? true : options.showTicker
     const format = { decimalSeparator, groupSeparator, groupSize: 3 }
     const roundingMode = options?.roundingMode || BigNumber.ROUND_DOWN
-    const decimalPlacesToDisplay = getVal(maxDecimalPlaces, this.type.format?.decimalPlaces)
-    const keepTrailingZeroes = getVal(
-      options?.showTrailingZeroes,
-      this.type.format?.showTrailingZeroes,
-    )
+    const decimalPlacesToDisplay = maxDecimalPlaces ?? this.type.format?.decimalPlaces
+    const keepTrailingZeroes = options?.showTrailingZeroes ?? this.type.format?.showTrailingZeroes
 
     let numberString = ''
     if (decimalPlacesToDisplay !== undefined && decimalPlacesToDisplay !== null) {
@@ -98,10 +88,7 @@ export default class Balance<T extends BaseCurrencyType> {
     } else {
       numberString = this.bigBalance.toFormat(format)
     }
-    // if it's an integer and keepTrailingZeroes is false, just show the integer
-    if (!keepTrailingZeroes && parseInt(numberString.split(decimalSeparator)[1], 10) === 0) {
-      numberString = numberString.split(decimalSeparator)[0]
-    }
+
     // if the rounded amount is 0, then show the full amount
     if (numberString === '0') {
       numberString = this.bigBalance.toFormat({ decimalSeparator, groupSeparator })

--- a/packages/currency/src/Balance.ts
+++ b/packages/currency/src/Balance.ts
@@ -35,6 +35,7 @@ type StringFormatOptions = {
   groupSeparator?: string
   showTicker?: boolean
   roundingMode?: BigNumber.RoundingMode
+  removeTrailingZeroes?: boolean
 }
 
 const DC_TO_USD_MULTIPLIER = 0.00001
@@ -69,14 +70,18 @@ export default class Balance<T extends BaseCurrencyType> {
     const groupSeparator = options?.groupSeparator || ','
     const showTicker = options?.showTicker === undefined ? true : options.showTicker
     const format = { decimalSeparator, groupSeparator, groupSize: 3 }
+    const roundingMode = options?.roundingMode || BigNumber.ROUND_DOWN
 
     let numberString = ''
     if (maxDecimalPlaces !== undefined && maxDecimalPlaces !== null) {
-      numberString = this.bigBalance.toFormat(
-        maxDecimalPlaces,
-        options?.roundingMode || BigNumber.ROUND_DOWN,
-        format,
-      )
+      let decimalPlaces = maxDecimalPlaces
+      if (options?.removeTrailingZeroes) {
+        decimalPlaces = Math.min(
+          maxDecimalPlaces,
+          this.bigBalance.decimalPlaces(maxDecimalPlaces, roundingMode).decimalPlaces(),
+        )
+      }
+      numberString = this.bigBalance.toFormat(decimalPlaces, roundingMode, format)
     } else {
       numberString = this.bigBalance.toFormat(format)
     }

--- a/packages/currency/src/__tests__/Balance.spec.ts
+++ b/packages/currency/src/__tests__/Balance.spec.ts
@@ -21,6 +21,28 @@ describe('toString', () => {
     expect(balance.toString(2)).toBe('2.99 MOBILE')
   })
 
+  it('removes trailing zeroes', () => {
+    const balance = new Balance(290000000, CurrencyType.mobile)
+    expect(balance.toString(9, { removeTrailingZeroes: true })).toBe('2.9 MOBILE')
+    expect(balance.toString(0, { removeTrailingZeroes: true })).toBe('2 MOBILE')
+
+    const balance2 = new Balance(20099000099, CurrencyType.mobile)
+    expect(balance2.toString(5, { removeTrailingZeroes: true })).toBe('200.99 MOBILE')
+    expect(balance2.toString(3, { removeTrailingZeroes: true })).toBe('200.99 MOBILE')
+    expect(balance2.toString(2, { removeTrailingZeroes: true })).toBe('200.99 MOBILE')
+    expect(balance2.toString(1, { removeTrailingZeroes: true })).toBe('200.9 MOBILE')
+    expect(balance2.toString(0, { removeTrailingZeroes: true })).toBe('200 MOBILE')
+  })
+
+  it('keeps non zero trailing decimals up to max precision', () => {
+    const balance = new Balance(20099999999, CurrencyType.mobile)
+    expect(balance.toString(5, { removeTrailingZeroes: true })).toBe('200.99999 MOBILE')
+    expect(balance.toString(3, { removeTrailingZeroes: true })).toBe('200.999 MOBILE')
+    expect(balance.toString(2, { removeTrailingZeroes: true })).toBe('200.99 MOBILE')
+    expect(balance.toString(1, { removeTrailingZeroes: true })).toBe('200.9 MOBILE')
+    expect(balance.toString(0, { removeTrailingZeroes: true })).toBe('200 MOBILE')
+  })
+
   it('handles numbers with a large amount of decimal places', () => {
     const balance = new Balance(1, CurrencyType.default)
     expect(balance.toString()).toBe('0.00000001 HNT')

--- a/packages/currency/src/__tests__/Balance.spec.ts
+++ b/packages/currency/src/__tests__/Balance.spec.ts
@@ -23,24 +23,43 @@ describe('toString', () => {
 
   it('removes trailing zeroes', () => {
     const balance = new Balance(290000000, CurrencyType.mobile)
-    expect(balance.toString(9, { removeTrailingZeroes: true })).toBe('2.9 MOBILE')
-    expect(balance.toString(0, { removeTrailingZeroes: true })).toBe('2 MOBILE')
+    expect(balance.toString(9)).toBe('2.9 MOBILE')
+    expect(balance.toString(0)).toBe('2 MOBILE')
 
     const balance2 = new Balance(20099000099, CurrencyType.mobile)
-    expect(balance2.toString(5, { removeTrailingZeroes: true })).toBe('200.99 MOBILE')
-    expect(balance2.toString(3, { removeTrailingZeroes: true })).toBe('200.99 MOBILE')
-    expect(balance2.toString(2, { removeTrailingZeroes: true })).toBe('200.99 MOBILE')
-    expect(balance2.toString(1, { removeTrailingZeroes: true })).toBe('200.9 MOBILE')
-    expect(balance2.toString(0, { removeTrailingZeroes: true })).toBe('200 MOBILE')
+    expect(balance2.toString(5)).toBe('200.99 MOBILE')
+    expect(balance2.toString(3)).toBe('200.99 MOBILE')
+    expect(balance2.toString(2)).toBe('200.99 MOBILE')
+    expect(balance2.toString(1)).toBe('200.9 MOBILE')
+    expect(balance2.toString(0)).toBe('200 MOBILE')
   })
 
   it('keeps non zero trailing decimals up to max precision', () => {
     const balance = new Balance(20099999999, CurrencyType.mobile)
-    expect(balance.toString(5, { removeTrailingZeroes: true })).toBe('200.99999 MOBILE')
-    expect(balance.toString(3, { removeTrailingZeroes: true })).toBe('200.999 MOBILE')
-    expect(balance.toString(2, { removeTrailingZeroes: true })).toBe('200.99 MOBILE')
-    expect(balance.toString(1, { removeTrailingZeroes: true })).toBe('200.9 MOBILE')
-    expect(balance.toString(0, { removeTrailingZeroes: true })).toBe('200 MOBILE')
+    expect(balance.toString(5)).toBe('200.99999 MOBILE')
+    expect(balance.toString(3)).toBe('200.999 MOBILE')
+    expect(balance.toString(2)).toBe('200.99 MOBILE')
+    expect(balance.toString(1)).toBe('200.9 MOBILE')
+    expect(balance.toString(0)).toBe('200 MOBILE')
+  })
+
+  it('keeps trailing decimals for USD', () => {
+    const balance = new Balance(20000000000, CurrencyType.usd)
+    expect(balance.toString(2)).toBe('200.00 USD')
+    expect(balance.toString(3)).toBe('200.000 USD')
+    expect(balance.toString()).toBe('200.00 USD')
+
+    const balance2 = new Balance(20059000000, CurrencyType.usd)
+    expect(balance2.toString(2)).toBe('200.59 USD')
+    expect(balance2.toString(3)).toBe('200.590 USD')
+    expect(balance2.toString()).toBe('200.59 USD')
+  })
+
+  it('removes trailing decimals for USD when specified', () => {
+    const balance = new Balance(20000000000, CurrencyType.usd)
+    expect(balance.toString(undefined, { showTrailingZeroes: false })).toBe('200 USD')
+    expect(balance.toString(2, { showTrailingZeroes: false })).toBe('200 USD')
+    expect(balance.toString(10, { showTrailingZeroes: false })).toBe('200 USD')
   })
 
   it('handles numbers with a large amount of decimal places', () => {
@@ -152,7 +171,7 @@ describe('toUsd', () => {
   it('converts a dc balance to a usd balance', () => {
     const dcBalance = new Balance(10 * 100000, CurrencyType.dataCredit)
     const usdBalance = dcBalance.toUsd()
-    expect(usdBalance.toString(2)).toBe('10 USD')
+    expect(usdBalance.toString(2)).toBe('10.00 USD')
   })
 
   it('converts an hnt balance to a usd balance', () => {
@@ -164,7 +183,7 @@ describe('toUsd', () => {
 
   it('returns itself if called on a usd balance', () => {
     const usdBalance = new Balance(10 * 100000000, CurrencyType.usd)
-    expect(usdBalance.toUsd().toString()).toBe('10 USD')
+    expect(usdBalance.toUsd().toString()).toBe('10.00 USD')
   })
 
   it('throws error when converting a mobile balance or iot', () => {

--- a/packages/currency/src/currency_types/BaseCurrencyType.ts
+++ b/packages/currency/src/currency_types/BaseCurrencyType.ts
@@ -6,6 +6,11 @@ function makeCoefficient(decimalPlaces: BigNumber): BigNumber {
   return one.dividedBy(ten.exponentiatedBy(decimalPlaces))
 }
 
+type CurrencyFormat = {
+  showTrailingZeroes?: boolean
+  decimalPlaces?: number
+}
+
 export default class BaseCurrencyType {
   public ticker: string
 
@@ -13,9 +18,12 @@ export default class BaseCurrencyType {
 
   public coefficient: BigNumber
 
-  constructor(ticker: string, decimalPlaces: number) {
+  public format?: CurrencyFormat
+
+  constructor(ticker: string, decimalPlaces: number, format?: CurrencyFormat) {
     this.ticker = ticker
     this.decimalPlaces = new BigNumber(decimalPlaces)
     this.coefficient = makeCoefficient(this.decimalPlaces)
+    this.format = format
   }
 }

--- a/packages/currency/src/currency_types/USDollars.ts
+++ b/packages/currency/src/currency_types/USDollars.ts
@@ -6,6 +6,6 @@ export default class USDollars extends BaseCurrencyType {
   // N.B. on the Helium blockchain, USD is represented
   // with 8 decimal places
   constructor() {
-    super(TICKER, 8)
+    super(TICKER, 8, { decimalPlaces: 2, showTrailingZeroes: true })
   }
 }


### PR DESCRIPTION
Creates formatting defaults for currencies when using `toString` 
Allows overriding defaults `balance.toString(10, { showTrailingZeroes: false })`

The only currency specifying default formatting is USD which is...
`{ decimalPlaces: 2, showTrailingZeroes: true }`
