### PR TITLE
add RSA and SECP256K1 key type support to @helium/address

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,6 @@
     "integration_tests",
     "packages/*"
   ],
-  "version": "4.10.1",
+  "version": "4.10.2",
   "npmClient": "yarn"
 }

--- a/packages/address/package.json
+++ b/packages/address/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helium/address",
-  "version": "4.8.1",
+  "version": "4.10.2",
   "description": "Helium public key utilities",
   "keywords": [
     "helium",

--- a/packages/address/src/KeyTypes.ts
+++ b/packages/address/src/KeyTypes.ts
@@ -1,12 +1,14 @@
 export const ECC_COMPACT_KEY_TYPE = 0
 export const ED25519_KEY_TYPE = 1
 export const MULTISIG_KEY_TYPE = 2
+export const SECP256K1_KEY_TYPE = 3
 export const RSA_KEY_TYPE = 4
 
 export const SUPPORTED_KEY_TYPES = [
   ECC_COMPACT_KEY_TYPE,
   ED25519_KEY_TYPE,
   MULTISIG_KEY_TYPE,
+  SECP256K1_KEY_TYPE,
   RSA_KEY_TYPE,
 ]
 

--- a/packages/address/src/KeyTypes.ts
+++ b/packages/address/src/KeyTypes.ts
@@ -1,11 +1,13 @@
 export const ECC_COMPACT_KEY_TYPE = 0
 export const ED25519_KEY_TYPE = 1
 export const MULTISIG_KEY_TYPE = 2
+export const RSA_KEY_TYPE = 4
 
 export const SUPPORTED_KEY_TYPES = [
   ECC_COMPACT_KEY_TYPE,
   ED25519_KEY_TYPE,
   MULTISIG_KEY_TYPE,
+  RSA_KEY_TYPE,
 ]
 
 export type KeyType = number

--- a/packages/address/src/__tests__/Address.spec.ts
+++ b/packages/address/src/__tests__/Address.spec.ts
@@ -6,6 +6,8 @@ import { MAINNET, TESTNET } from '../NetTypes'
 const ECC_COMPACT_ADDRESS = '112qB3YaH5bZkCnKA5uRH7tBtGNv2Y5B4smv1jsmvGUzgKT71QpE'
 const BTC_ADDRESS = '18wxa7qM8C8AXmGwJj13C7sGqn8hyFdcdR'
 const TESTNET_ADDRESS = '1bijtibPhc16wx4oJbyK8vtkAgdoRoaUvJeo7rXBnBCufEYakfd'
+const RSA_ADDRESS =
+  '1trSusebcQv2kJfLEUV1D4RQyHZyTfFkvFxWBUa1iv53eZKhyg1iDWGsWo89w8HzQBx3vzoeB85aDYK9w2oX1LdWdnrq5QL4M8iGDDacdp5FeSvXTwr6RB9Hv86qQSFT3ppdTSk6Jbe8eDK81NcNNrkhRXqfmH3CAHRCmrKwLcNBLzxo2a8hqQi1rsW8z9dJgWKMsx2cWoboaGgqrfsRC54WJuPWZwkRCmP7dHArxyWqibicaicBoq5yqW3QsTvxTXLHMUVXr59BQriu75QFiztCYiFjq13Qp6kVkFdXwZ5S2cSVZSsg9d1uB4eN3VK4wYefKFnR9qQT5S93CFFX9nXQx7wi5Z6MdAj1mmu6yZczCE'
 
 describe('b58', () => {
   it('returns a b58 check encoded representation of the address', async () => {
@@ -22,6 +24,11 @@ describe('b58', () => {
   it('supports ecc_compact addresses', () => {
     const address = Address.fromB58(ECC_COMPACT_ADDRESS)
     expect(address.b58).toBe(ECC_COMPACT_ADDRESS)
+  })
+
+  it('supports rsa addresses', () => {
+    const address = Address.fromB58(RSA_ADDRESS)
+    expect(address.b58).toBe(RSA_ADDRESS)
   })
 })
 
@@ -57,8 +64,7 @@ describe('unsupported key types', () => {
   })
 
   it('throws an error if initialized with an unsupported key type', async () => {
-    expect(() => new Address(0, MAINNET, 57, Buffer.from('some random public key')))
-      .toThrow()
+    expect(() => new Address(0, MAINNET, 57, Buffer.from('some random public key'))).toThrow()
   })
 })
 
@@ -66,6 +72,7 @@ describe('isValid', () => {
   it('returns true if the address is valid and supported', () => {
     expect(Address.isValid(bobB58)).toBeTruthy()
     expect(Address.isValid(ECC_COMPACT_ADDRESS)).toBeTruthy()
+    expect(Address.isValid(RSA_ADDRESS)).toBeTruthy()
   })
 
   it('returns false if the address is not valid', () => {

--- a/packages/address/src/__tests__/Address.spec.ts
+++ b/packages/address/src/__tests__/Address.spec.ts
@@ -8,6 +8,7 @@ const BTC_ADDRESS = '18wxa7qM8C8AXmGwJj13C7sGqn8hyFdcdR'
 const TESTNET_ADDRESS = '1bijtibPhc16wx4oJbyK8vtkAgdoRoaUvJeo7rXBnBCufEYakfd'
 const RSA_ADDRESS =
   '1trSusebcQv2kJfLEUV1D4RQyHZyTfFkvFxWBUa1iv53eZKhyg1iDWGsWo89w8HzQBx3vzoeB85aDYK9w2oX1LdWdnrq5QL4M8iGDDacdp5FeSvXTwr6RB9Hv86qQSFT3ppdTSk6Jbe8eDK81NcNNrkhRXqfmH3CAHRCmrKwLcNBLzxo2a8hqQi1rsW8z9dJgWKMsx2cWoboaGgqrfsRC54WJuPWZwkRCmP7dHArxyWqibicaicBoq5yqW3QsTvxTXLHMUVXr59BQriu75QFiztCYiFjq13Qp6kVkFdXwZ5S2cSVZSsg9d1uB4eN3VK4wYefKFnR9qQT5S93CFFX9nXQx7wi5Z6MdAj1mmu6yZczCE'
+const SECP256K1_ADDRESS = '1SpLY6fic4fGthLGjeAUdLVNVYk1gJGrWTGhsukm2dnELaSEQmhL'
 
 describe('b58', () => {
   it('returns a b58 check encoded representation of the address', async () => {
@@ -29,6 +30,11 @@ describe('b58', () => {
   it('supports rsa addresses', () => {
     const address = Address.fromB58(RSA_ADDRESS)
     expect(address.b58).toBe(RSA_ADDRESS)
+  })
+
+  it('supports secp256k1 addresses', () => {
+    const address = Address.fromB58(SECP256K1_ADDRESS)
+    expect(address.b58).toBe(SECP256K1_ADDRESS)
   })
 })
 
@@ -73,6 +79,7 @@ describe('isValid', () => {
     expect(Address.isValid(bobB58)).toBeTruthy()
     expect(Address.isValid(ECC_COMPACT_ADDRESS)).toBeTruthy()
     expect(Address.isValid(RSA_ADDRESS)).toBeTruthy()
+    expect(Address.isValid(SECP256K1_ADDRESS)).toBeTruthy()
   })
 
   it('returns false if the address is not valid', () => {

--- a/packages/crypto-react-native/package.json
+++ b/packages/crypto-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helium/crypto-react-native",
-  "version": "4.8.1",
+  "version": "4.10.2",
   "description": "Cryptography utilities including mnemonics, keypairs and base58-check encoding for React Native",
   "keywords": [
     "helium",
@@ -27,7 +27,7 @@
     "build": "yarn run clean && tsc"
   },
   "dependencies": {
-    "@helium/address": "^4.8.1",
+    "@helium/address": "^4.10.2",
     "js-sha256": "^0.9.0",
     "react-native-sodium": "^0.4.0",
     "safe-buffer": "^5.2.1"

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helium/crypto",
-  "version": "4.10.1",
+  "version": "4.10.2",
   "description": "Cryptography utilities including mnemonics, keypairs and base58-check encoding",
   "keywords": [
     "helium",
@@ -26,7 +26,7 @@
     "build": "yarn run clean && tsc"
   },
   "dependencies": {
-    "@helium/address": "^4.8.1",
+    "@helium/address": "^4.10.2",
     "create-hash": "^1.2.0",
     "libsodium-wrappers": "^0.7.6"
   },

--- a/packages/currency/package.json
+++ b/packages/currency/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helium/currency",
-  "version": "4.10.1",
+  "version": "4.10.2",
   "description": "Utilities for handling different currency types on the Helium blockchain",
   "keywords": [
     "helium",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helium/http",
-  "version": "4.10.1",
+  "version": "4.10.2",
   "description": "HTTP library for interacting with the Helium blockchain API",
   "keywords": [
     "helium",
@@ -26,8 +26,8 @@
     "build": "yarn run clean && tsc"
   },
   "dependencies": {
-    "@helium/address": "^4.8.1",
-    "@helium/currency": "^4.10.1",
+    "@helium/address": "^4.10.2",
+    "@helium/currency": "^4.10.2",
     "axios": "^0.21.1",
     "camelcase-keys": "^6.2.2",
     "qs": "^6.9.3",

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helium/onboarding",
-  "version": "4.10.1",
+  "version": "4.10.2",
   "description": "HTTP library for interacting with an onboarding server",
   "keywords": [
     "helium",

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helium/transactions",
-  "version": "4.10.1",
+  "version": "4.10.2",
   "description": "Construct and serialize Helium blockchain transaction primatives",
   "keywords": [
     "helium",
@@ -27,14 +27,14 @@
     "build": "yarn run clean && tsc"
   },
   "dependencies": {
-    "@helium/address": "^4.8.1",
+    "@helium/address": "^4.10.2",
     "@helium/proto": "^1.6.0",
     "@types/libsodium-wrappers": "^0.7.8",
     "long": "^4.0.0",
     "path": "^0.12.7"
   },
   "devDependencies": {
-    "@helium/crypto": "^4.10.1"
+    "@helium/crypto": "^4.10.2"
   },
   "gitHead": "07d361645c7851908721d7fbd70c6f9a39c3b210"
 }

--- a/packages/wallet-link/package.json
+++ b/packages/wallet-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helium/wallet-link",
-  "version": "4.10.1",
+  "version": "4.10.2",
   "description": "Utilities for linking a 3rd party app to the helium wallet.",
   "keywords": [
     "helium",
@@ -26,8 +26,8 @@
     "build": "yarn run clean && tsc"
   },
   "dependencies": {
-    "@helium/address": "^4.8.1",
-    "@helium/transactions": "^4.10.1",
+    "@helium/address": "^4.10.2",
+    "@helium/transactions": "^4.10.2",
     "date-fns": "^2.28.0",
     "query-string": "^7.1.1"
   },
@@ -35,7 +35,7 @@
     "@helium/crypto": "^4.3.1"
   },
   "devDependencies": {
-    "@helium/crypto": "^4.10.1"
+    "@helium/crypto": "^4.10.2"
   },
   "gitHead": "07d361645c7851908721d7fbd70c6f9a39c3b210"
 }


### PR DESCRIPTION
adds support for RSA and  SECP256K1 key types to the @helium/address package.

Using the following for keytype definitions: https://github.com/helium/helium-crypto-rs/blob/main/src/lib.rs#L244